### PR TITLE
Add support for streaming NAR output

### DIFF
--- a/src/Main.hs
+++ b/src/Main.hs
@@ -12,10 +12,11 @@ import Data.CharSet.ByteSet (ByteSet(..))
 import Data.Function ((&))
 import Network.Socket (SockAddr(..))
 import Network.Wai (Application)
-import Nix (PathInfo(..))
+import Nix (NoSuchPath(..), PathInfo(..))
 import Numeric.Natural (Natural)
 import Options (Options(..), Socket(..), SSL(..), Verbosity(..))
 
+import qualified Control.Exception                    as Exception
 import qualified Control.Monad                        as Monad
 import qualified Control.Monad.Except                 as Except
 import qualified Data.ByteString                      as ByteString
@@ -112,8 +113,8 @@ makeApplication ApplicationOptions{..} request respond = do
                 maybeStorePath <- liftIO (Nix.queryPathFromHashPart hashPart)
 
                 storePath <- case maybeStorePath of
-                    Nothing        -> noSuchPath
-                    Just storePath -> return storePath
+                    Left NoSuchPath -> noSuchPath
+                    Right storePath -> return storePath
 
                 pathInfo@PathInfo{..} <- liftIO (Nix.queryPathInfo storePath)
 
@@ -230,8 +231,8 @@ makeApplication ApplicationOptions{..} request respond = do
                 maybeStorePath <- liftIO (Nix.queryPathFromHashPart hashPart)
 
                 storePath <- case maybeStorePath of
-                    Nothing        -> noSuchPath
-                    Just storePath -> return storePath
+                    Left  NoSuchPath-> noSuchPath
+                    Right storePath -> return storePath
 
                 PathInfo{ narHash } <- liftIO (Nix.queryPathInfo storePath)
 
@@ -249,7 +250,12 @@ makeApplication ApplicationOptions{..} request respond = do
 
                     done response
 
-                let streamingBody write flush = Nix.dumpPath hashPart callback
+                let streamingBody write flush = do
+                       result <- Nix.dumpPath hashPart callback
+
+                       case result of
+                           Left  exception -> Exception.throwIO exception
+                           Right x         -> return x
                       where
                         callback builder = do
                             () <- write builder


### PR DESCRIPTION
Before this change the NAR contents would be buffered in memory before
supplying them to the client.  Now each chunk is instantly flushed
to the client when it's available.

This requires reworking things so that we use a `StreamingBody`,
which in turn requires passing a Haskell callback to the C code to
invoke.