### PR TITLE
Benchmark using wallclock time instead of CPU time

### DIFF
--- a/benchmark/Main.hs
+++ b/benchmark/Main.hs
@@ -1,6 +1,16 @@
 {-# LANGUAGE BlockArguments    #-}
 {-# LANGUAGE OverloadedStrings #-}
 
+{-| To benchmark `nix-serve-ng`, run the following commands:
+
+    > $ nix build
+    > $ PATH="./result/bin:${PATH}" cabal v1-bench --benchmark-option=--time-mode=wall
+
+    You can compare against the old `nix-serve` by changing the first command
+    to:
+
+    > $ nix build --file '<nixpkgs>' nix-serve
+-}
 module Main where
 
 import Control.Applicative (empty)

--- a/flake.lock
+++ b/flake.lock
@@ -18,16 +18,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1653936696,
-        "narHash": "sha256-M6bJShji9AIDZ7Kh7CPwPBPb/T7RiVev2PAcOi4fxDQ=",
+        "lastModified": 1661799778,
+        "narHash": "sha256-0fIYh7sOcQOPv0zs+B02Ovx1i40qgx1W1HQJiudCrnQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ce6aa13369b667ac2542593170993504932eb836",
+        "rev": "7517de391d12a21cd6f6f86df2c42f9ea90237e8",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "22.05",
+        "ref": "master",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -41,11 +41,11 @@
     },
     "utils": {
       "locked": {
-        "lastModified": 1656065134,
-        "narHash": "sha256-oc6E6ByIw3oJaIyc67maaFcnjYOz1mMcOtHxbEf9NwQ=",
+        "lastModified": 1659877975,
+        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "bee6a7250dd1b01844a2de7e02e4df7d8a0a206c",
+        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -1,5 +1,5 @@
 { inputs = {
-    nixpkgs.url = github:NixOS/nixpkgs/22.05;
+    nixpkgs.url = github:NixOS/nixpkgs/master;
 
     utils.url = github:numtide/flake-utils;
 


### PR DESCRIPTION
This requires upgrading to a newer version of `nixpkgs` to pick up
a newer version of the `tasty-bench` package in order to support
benchmarking using wall-clock time