### PR TITLE
Fix default NixOS module

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -90,7 +90,7 @@
         #
         # You can continue to use the old `services.nix-serve` NixOS options.
         nixosModules.default = {
-          nixpkgs.overlays = overlays.default;
+          nixpkgs.overlays = overlays.override;
         };
       };
 }


### PR DESCRIPTION
… to correctly override `pkgs.nix-serve` with `pkgs.nix-serve-ng`