### PR TITLE
Include `nix.hh` in the source distribution

### DIFF
--- a/nix-serve-ng.cabal
+++ b/nix-serve-ng.cabal
@@ -33,6 +33,7 @@ executable nix-serve
     include-dirs:     cbits
 
     cxx-sources:      cbits/nix.cpp
+                    , cbits/nix.hh
 
     cxx-options:      -std=c++17
 


### PR DESCRIPTION
Fixes https://github.com/aristanetworks/nix-serve-ng/issues/10