### PR TITLE
Fix builds on Darwin

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,11 +114,9 @@ Did we satisfy those requirements?
 
 * Backwards-compatibility
 
-  We have excellent backwards-compatibility with one major exception:
-  `nix-serve-ng` does not support MacOS (whereas `nix-serve` does).
-
-  Other than that, in the vast majority of cases, you can simply replace
-  `pkgs.nix-serve` with `pkgs.nix-serve-ng` and make no other changes.
+  We have excellent backwards-compatibility, so in the vast majority of cases,
+  you can simply replace `pkgs.nix-serve` with `pkgs.nix-serve-ng` and make no
+  other changes.
 
   * Our executable shares the same name (`nix-serve`) as the original program
 

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "flake-compat": {
       "flake": false,
       "locked": {
-        "lastModified": 1650374568,
-        "narHash": "sha256-Z+s0J8/r907g149rllvwhb4pKi8Wam5ij0st8PwAh+E=",
+        "lastModified": 1668681692,
+        "narHash": "sha256-Ht91NGdewz8IQLtWZ9LCeNXMSXHUss+9COoqu6JLmXU=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "b4a34015c698c7793d592d66adbab377907a2be8",
+        "rev": "009399224d5e398d03b22badca40a37ac85412a1",
         "type": "github"
       },
       "original": {
@@ -18,11 +18,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1661799778,
-        "narHash": "sha256-0fIYh7sOcQOPv0zs+B02Ovx1i40qgx1W1HQJiudCrnQ=",
+        "lastModified": 1669391192,
+        "narHash": "sha256-f/2TqduZWcdq/pPddu1E7plNmcOuzt1IN4Fh3LSUKmM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "7517de391d12a21cd6f6f86df2c42f9ea90237e8",
+        "rev": "ce1f9354959ae1493916f2e551ecc32e79b4a473",
         "type": "github"
       },
       "original": {
@@ -41,11 +41,11 @@
     },
     "utils": {
       "locked": {
-        "lastModified": 1659877975,
-        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
+        "lastModified": 1667395993,
+        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
+        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -12,6 +12,10 @@
   outputs = { nixpkgs, utils, ... }:
     let
       overlay = pkgsNew: pkgsOld: {
+        cabal2nix-unwrapped =
+          pkgsNew.haskell.lib.justStaticExecutables
+            pkgsNew.haskell.packages.ghc92.cabal2nix;
+
         haskellPackages = pkgsOld.haskellPackages.override (old: {
           overrides =
             pkgsNew.lib.fold pkgsNew.lib.composeExtensions (old.overrides or (_: _: { })) [

--- a/nix-serve-ng.cabal
+++ b/nix-serve-ng.cabal
@@ -1,4 +1,4 @@
-cabal-version:      3.0
+cabal-version:      3.6
 name:               nix-serve-ng
 version:            1.0.0
 synopsis:
@@ -59,6 +59,7 @@ executable nix-serve
 
     if os(darwin)
       extra-libraries: c++
+      hsc2hs-options: --cc clang++
     elif os(linux)
       extra-libraries: stdc++
     else


### PR DESCRIPTION
… using the trick that @roberth taught me here:

https://github.com/NixOS/nixpkgs/pull/196646#issuecomment-1327364634

This requires bumping the Cabal format version, which in turn requires bumping the version of `cabal2nix`

Fixes https://github.com/aristanetworks/nix-serve-ng/issues/13