### PR TITLE
Fix #19

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -11,12 +11,14 @@
 
   outputs = { nixpkgs, utils, ... }:
     let
-      compiler = "ghc92";
+      compiler = "ghc810";
 
       overlay = pkgsNew: pkgsOld: {
         cabal2nix-unwrapped =
           pkgsNew.haskell.lib.justStaticExecutables
-            pkgsNew.haskell.packages."${compiler}".cabal2nix;
+            # use cabal2nix from 9.2 here, because cabal2nix from 8.10 can't
+            # read cabal-version: 3.6
+            pkgsNew.haskell.packages.ghc92.cabal2nix;
 
         haskell = pkgsOld.haskell // {
           packages = pkgsOld.haskell.packages // {


### PR DESCRIPTION
This fixes #19 by downgrading the compiler to 8.10 (I still don't think 9.0 should be used in production). bytestring < 0.11.4 (which as of today has not been released to https://hackage.haskell.org/package/bytestring), is broken, as per haskell/bytestring#538. This in turn shows up in yesodweb/wai#894, and ultimately causes #19.