### PR TITLE
Revert "Call initLibStore before opening store (#23)"

### DIFF
--- a/cbits/nix.cpp
+++ b/cbits/nix.cpp
@@ -14,7 +14,6 @@ static ref<Store> getStore()
     static std::shared_ptr<Store> _store;
 
     if (!_store) {
-        initLibStore();
         loadConfFile();
 
         _store = openStore();


### PR DESCRIPTION
Fixes https://github.com/aristanetworks/nix-serve-ng/issues/24

This reverts commit dabf46d65d8e3be80fa2eacd229eb3e621add4bd.