### PR TITLE
Fix Nix build

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -25,6 +25,8 @@
                 final.lib.fold final.lib.composeExtensions (old.overrides or (_: _: { })) [
                   (final.haskell.lib.packageSourceOverrides {
                     nix-serve-ng = ./.;
+
+                    base16 = "1.0";
                   })
                   (haskellPackagesNew: haskellPackagesOld: {
                     nix-serve-ng =


### PR DESCRIPTION
… by bumping `base-16` to version 1.0.0 to match the constraint added in https://github.com/aristanetworks/nix-serve-ng/pull/33

Fixes https://github.com/aristanetworks/nix-serve-ng/issues/34