### PR TITLE
fix build against Nix 2.24

### DIFF
--- a/cbits/nix.cpp
+++ b/cbits/nix.cpp
@@ -1,6 +1,7 @@
 #include <cstddef>
 #include <cstdlib>
 #include <nix/store-api.hh>
+#include <nix/shared.hh>
 #include <nix/log-store.hh>
 #include "nix.hh"
 
@@ -14,8 +15,7 @@ static ref<Store> getStore()
     static std::shared_ptr<Store> _store;
 
     if (!_store) {
-        initLibStore();
-        loadConfFile();
+        initLibStore(true);
 
         _store = openStore();
     }
@@ -120,7 +120,7 @@ void queryPathInfo
         output->deriver = emptyString;
     };
 
-    copyString(validPathInfo->narHash.to_string(Base32, true), &output->narHash);
+    copyString(validPathInfo->narHash.to_string(nix::HashFormat::Nix32, true), &output->narHash);
 
     output->narSize = validPathInfo->narSize;
 

--- a/flake.lock
+++ b/flake.lock
@@ -18,11 +18,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1700856099,
-        "narHash": "sha256-RnEA7iJ36Ay9jI0WwP+/y4zjEhmeN6Cjs9VOFBH7eVQ=",
+        "lastModified": 1732238832,
+        "narHash": "sha256-sQxuJm8rHY20xq6Ah+GwIUkF95tWjGRd1X8xF+Pkk38=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0bd59c54ef06bc34eca01e37d689f5e46b3fe2f1",
+        "rev": "8edf06bea5bcbee082df1b7369ff973b91618b8d",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -35,6 +35,7 @@
                         (old: {
                           executableSystemDepends = (old.executableSystemDepends or []) ++ [
                             final.boost.dev
+                            final.nixVersions.nix_2_24
                           ];
                         });
                   })

--- a/nix-serve-ng.cabal
+++ b/nix-serve-ng.cabal
@@ -36,7 +36,7 @@ executable nix-serve
     cxx-sources:      cbits/nix.cpp
                     , cbits/nix.hh
 
-    cxx-options:      -std=c++17
+    cxx-options:      -std=c++20
 
     build-depends:    base < 5
                     , base16 >= 1.0


### PR DESCRIPTION
nix-serve-ng still depends on nix 2.18, which we want to remove from nixpkgs.
This patch fix the build against newer nix versions