### PR TITLE
Support Lix 2.92

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,12 @@ in
 }
 ```
 
+## Lix compatability
+
+The default `nix-serve-ng` should work on top of lix, but if you want to build
+it against lix for development or to remove the default nix dependency, you can
+pass `-f lix` to cabal or use the `lix-serve-ng` package from the flake.
+
 ## Motivation
 
 Our requirements for this project were:

--- a/cbits/nix.cpp
+++ b/cbits/nix.cpp
@@ -1,9 +1,15 @@
 #include <cstddef>
 #include <cstdlib>
 
-#include <nix/store/store-api.hh>
-#include <nix/store/log-store.hh>
-#include <nix/main/shared.hh>
+#ifndef LIX
+    #include <nix/store/store-api.hh>
+    #include <nix/store/log-store.hh>
+    #include <nix/main/shared.hh>
+#else
+    #include <lix/libstore/store-api.hh>
+    #include <lix/libstore/log-store.hh>
+    #include <lix/libmain/shared.hh>
+#endif
 
 #include "nix.hh"
 
@@ -17,7 +23,11 @@ static ref<Store> getStore()
     static std::shared_ptr<Store> _store;
 
     if (!_store) {
+#ifndef LIX
         initLibStore(true);
+#else
+        initNix();
+#endif
 
         _store = openStore();
     }
@@ -122,7 +132,11 @@ void queryPathInfo
         output->deriver = emptyString;
     };
 
+#ifndef LIX
     copyString(validPathInfo->narHash.to_string(nix::HashFormat::Nix32, true), &output->narHash);
+#else
+    copyString(validPathInfo->narHash.to_string(nix::Base::Base32, true), &output->narHash);
+#endif
 
     output->narSize = validPathInfo->narSize;
 
@@ -185,7 +199,11 @@ bool dumpPath
         });
 
         try {
+#ifndef LIX
             store->narFromPath(storePath.value(), sink);
+#else
+            sink << store->narFromPath(storePath.value());
+#endif
         } catch (const std::runtime_error & e) {
             // Intentionally do nothing.  We're only using the exception as a
             // short-circuiting mechanism.

--- a/flake.lock
+++ b/flake.lock
@@ -16,7 +16,93 @@
         "type": "github"
       }
     },
+    "flake-compat_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1696426674,
+        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "lix": {
+      "inputs": {
+        "flake-compat": "flake-compat_2",
+        "nix2container": "nix2container",
+        "nixpkgs": "nixpkgs",
+        "nixpkgs-regression": "nixpkgs-regression",
+        "pre-commit-hooks": "pre-commit-hooks"
+      },
+      "locked": {
+        "lastModified": 1737234286,
+        "narHash": "sha256-CCKIAE84dzkrnlxJCKFyffAxP3yfsOAbdvydUGqq24g=",
+        "rev": "2837da71ec1588c1187d2e554719b15904a46c8b",
+        "revCount": 16631,
+        "type": "git",
+        "url": "https://git.lix.systems/lix-project/lix"
+      },
+      "original": {
+        "rev": "2837da71ec1588c1187d2e554719b15904a46c8b",
+        "type": "git",
+        "url": "https://git.lix.systems/lix-project/lix"
+      }
+    },
+    "nix2container": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1724996935,
+        "narHash": "sha256-njRK9vvZ1JJsP8oV2OgkBrpJhgQezI03S7gzskCcHos=",
+        "owner": "nlewo",
+        "repo": "nix2container",
+        "rev": "fa6bb0a1159f55d071ba99331355955ae30b3401",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nlewo",
+        "repo": "nix2container",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
+      "locked": {
+        "lastModified": 1733348545,
+        "narHash": "sha256-b4JrUmqT0vFNx42aEN9LTWOHomkTKL/ayLopflVf81U=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "9ecb50d2fae8680be74c08bb0a995c5383747f89",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-24.11-small",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-regression": {
+      "locked": {
+        "lastModified": 1643052045,
+        "narHash": "sha256-uGJ0VXIhWKGXxkeNnq4TvV3CIOkUJ3PAoLZ3HMzNVMw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
       "locked": {
         "lastModified": 1744174375,
         "narHash": "sha256-oxI9TLgnQbQ/WL0tIwVSIooLbXq4PW1QUhf5aQmXFgk=",
@@ -32,10 +118,27 @@
         "type": "github"
       }
     },
+    "pre-commit-hooks": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1733318908,
+        "narHash": "sha256-SVQVsbafSM1dJ4fpgyBqLZ+Lft+jcQuMtEL3lQWx2Sk=",
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "rev": "6f4e2a2112050951a314d2733a994fbab94864c6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "flake-compat": "flake-compat",
-        "nixpkgs": "nixpkgs",
+        "lix": "lix",
+        "nixpkgs": "nixpkgs_2",
         "utils": "utils"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -44,6 +44,7 @@
                   });
                   lix-serve-ng = final.haskell.lib.overrideCabal haskellPackagesOld.lix-serve-ng (old: {
                     pname = "lix-serve-ng";
+                    configureFlags = (old.configureFlags or [ ]) ++ [ "-flix" ];
                     executableSystemDepends = (old.executableSystemDepends or [ ]) ++ [
                       final.boost.dev
                       final.lix

--- a/flake.nix
+++ b/flake.nix
@@ -3,6 +3,8 @@
     # Temporary, until Nixpkgs master has Nix 2.28
     nixpkgs.url = "github:NixOS/nixpkgs/master";
 
+    lix.url = "git+https://git.lix.systems/lix-project/lix?rev=2837da71ec1588c1187d2e554719b15904a46c8b";
+
     utils.url = "github:numtide/flake-utils";
 
     flake-compat = {
@@ -12,11 +14,13 @@
   };
 
   outputs =
-    { nixpkgs, utils, ... }:
+    { nixpkgs, lix, utils, ... }:
     let
       compiler = "ghc94";
 
       overlay = final: prev: {
+        lix = lix.packages.${final.system}.default;
+
         cabal2nix-unwrapped =
           final.haskell.lib.justStaticExecutables
             final.haskell.packages."${compiler}".cabal2nix;
@@ -27,6 +31,7 @@
               overrides = final.lib.fold final.lib.composeExtensions (old.overrides or (_: _: { })) [
                 (final.haskell.lib.packageSourceOverrides {
                   nix-serve-ng = ./.;
+                  lix-serve-ng = ./.;
 
                   base16 = "1.0";
                 })
@@ -35,6 +40,13 @@
                     executableSystemDepends = (old.executableSystemDepends or [ ]) ++ [
                       final.boost.dev
                       final.nixVersions.nix_2_28
+                    ];
+                  });
+                  lix-serve-ng = final.haskell.lib.overrideCabal haskellPackagesOld.lix-serve-ng (old: {
+                    pname = "lix-serve-ng";
+                    executableSystemDepends = (old.executableSystemDepends or [ ]) ++ [
+                      final.boost.dev
+                      final.lix
                     ];
                   });
                 })
@@ -46,6 +58,10 @@
         nix-serve-ng =
           final.haskell.lib.justStaticExecutables
             final.haskell.packages."${compiler}".nix-serve-ng;
+
+        lix-serve-ng =
+          final.haskell.lib.justStaticExecutables
+            final.haskell.packages."${compiler}".lix-serve-ng;
       };
 
     in
@@ -60,24 +76,36 @@
           inherit system;
         };
 
-        inherit (pkgs) nix-serve-ng;
+        inherit (pkgs) nix-serve-ng lix-serve-ng;
 
       in
       rec {
-        packages.default = nix-serve-ng;
+        packages = {
+          inherit nix-serve-ng lix-serve-ng;
+          default = nix-serve-ng;
+        };
 
         defaultPackage = packages.default;
 
-        apps.default = {
-          type = "app";
-
-          program = "${nix-serve-ng}/bin/nix-serve";
+        apps = rec {
+          default = nix-serve-ng;
+          nix-serve-ng = {
+            type = "app";
+            program = "${nix-serve-ng}/bin/nix-serve";
+          };
+          lix-serve-ng = {
+            type = "app";
+            program = "${lix-serve-ng}/bin/nix-serve";
+          };
         };
 
         defaultApp = apps.default;
 
-        devShells.default =
-          (pkgs.haskell.lib.doBenchmark pkgs.haskell.packages."${compiler}".nix-serve-ng).env;
+        devShells = rec {
+          default = nix-serve-ng;
+          nix-serve-ng = (pkgs.haskell.lib.doBenchmark pkgs.haskell.packages."${compiler}".nix-serve-ng).env;
+          lix-serve-ng = (pkgs.haskell.lib.doBenchmark pkgs.haskell.packages."${compiler}".lix-serve-ng).env;
+        };
 
         devShell = devShells.default;
       }

--- a/nix-serve-ng.cabal
+++ b/nix-serve-ng.cabal
@@ -11,6 +11,11 @@ maintainer:         opensource@awakesecurity.com
 copyright:          2022 Arista Networks
 extra-source-files: CHANGELOG.md
 
+Flag Lix
+  Description: Build against Lix
+  Default:     False
+  Manual:      True
+
 executable nix-serve
     hs-source-dirs:   src
 
@@ -55,8 +60,14 @@ executable nix-serve
                     , warp
                     , warp-tls
 
-    pkgconfig-depends:
-                      nix-store
+    if flag(lix)
+      cxx-options:      -DLIX
+      pkgconfig-depends:
+                      , lix-main
+                      , lix-store
+    else
+      pkgconfig-depends:
+                        nix-store
 
     if os(darwin)
       extra-libraries: c++


### PR DESCRIPTION
nix-serve-ng can now build against lix by passing -f lix to cabal

the flake now also exports the `lix-serve-ng` package for a version that is built against lix

closes: #39