### PR TITLE
Support use as a reverse proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # `nix-serve-ng`
 
-`nix-serve-ng` is a faster, more reliable, drop-in replacement for `nix-serve`.
+`nix-serve-ng` is a faster, more reliable, more flexible replacement for `nix-serve`.
 
 ## Quick start
 
@@ -19,19 +19,19 @@ the old `nix-serve` with `nix-serve-ng`:
 We recommend approach **A**. Only use **B** or **C** if you need a bleeding edge
 upstream version of the project.
 
-### Variant A: 
+### Variant A:
 
 _The code snippet below shows a `flake.nix`._
 
 ```nix
-{ 
+{
   inputs.nixpkgs.url = "github:NixOS/nixpkgs";
 
   outputs = { nixpkgs, ... }: {
     nixosConfigurations.default = nixpkgs.lib.nixosSystem {
       modules = [
         /* ... */
-        { 
+        {
           services.nix-serve.enable = true;
           services.nix-serve.package = pkgs.nix-serve-ng;
           /* ... */
@@ -43,12 +43,12 @@ _The code snippet below shows a `flake.nix`._
 }
 ```
 
-### Variant B: 
+### Variant B:
 
 _The code snippet below shows a `flake.nix`._
 
 ```nix
-{ 
+{
   inputs.nixpkgs.url = "github:NixOS/nixpkgs";
   inputs.nix-serve-ng.url = "github:aristanetworks/nix-serve-ng";
 
@@ -57,7 +57,7 @@ _The code snippet below shows a `flake.nix`._
       modules = [
         nix-serve-ng.nixosModules.default
         /* ... */
-        { 
+        {
           services.nix-serve.enable = true;
           /* ... */
         }
@@ -68,14 +68,14 @@ _The code snippet below shows a `flake.nix`._
 }
 ```
 
-### Variant C: 
+### Variant C:
 
 _The code snippet below shows a NixOS module file._
 
 ```nix
 { config, pkgs, lib, ... }:
 
-let 
+let
   nix-serve-ng-src = builtins.fetchTarball {
     # Replace the URL and hash with whatever you actually need
     url    = "https://github.com/aristanetworks/nix-serve-ng/archive/1937593598bb1285b41804f25cd6f9ddd4d5f1cb.tar.gz";
@@ -85,10 +85,10 @@ let
 
   nix-serve-ng = import nix-serve-ng-src;
 in
-{ 
+{
   /* ... */
   imports = [ nix-serve-ng.nixosModules.default ];
-  
+
   config = {
     services.nix-serve.enable = true;
   };
@@ -96,7 +96,56 @@ in
 }
 ```
 
-## Lix compatability
+## New Features of `nix-serve-ng`
+
+### Reverse Proxying with --store URL
+
+`nix-serve-ng` can connect to other substituters with the --store option.
+
+URL is a standard nix store url see: `nix help-stores` for details.
+
+`--store=URL` can be specified more than once. Stores will be queried order of
+the `priority` query parameter (lowest to highest). Sets of stores with the same
+priority will be queried concurrently.
+
+`--retry-timeout=SECONDS` specifies how long to wait after a store operation
+fails before reenabling the store. The default is the value of the nix setting
+`connect-timeout`.
+
+`--cores=N` specifies the maximum number of cores. The default value is the
+size of the largest group of stores with the same priority.
+
+Example: You have two caches that are equally fast. One for releases without a
+retention policy, and one for build artifacts with 1 month retentions. You also
+want to fall back to the local store.
+
+```bash
+--store s3://releases --store s3://cache \
+--store daemon?priority=1
+```
+
+Example: First try a local binary cache, then an s3 binary cache, and then try
+remote builders.
+
+```bash
+--store file:///srv/hot \
+--store s3://cold?priority=1 \
+--store http://bld1?priority=2 --store http://bld2?priority=2
+```
+
+### Expanded logging options
+
+The following are available with `--log-format`:
+
+```bash
+quiet       Do not log
+normal      Apache logging format (default)
+real-ip     Apache logging format with ip forwarding resolved
+verbose     Verbose logging with colored output
+debug       Verbose logging with uncolored output
+```
+
+### Lix compatability
 
 The default `nix-serve-ng` should work on top of lix, but if you want to build
 it against lix for development or to remove the default nix dependency, you can
@@ -257,7 +306,7 @@ Speedups (compared to `nix-serve`):
 
 We can summarize `nix-serve-ng`'s performance like this:
 
-* Time to handle a NAR info request: ≈ 100 μs 
+* Time to handle a NAR info request: ≈ 100 μs
 * Time to serve a NAR: ≈ 500 μs + 800 μs / MB
 
 You can reproduce these benchmarks using the benchmark suite.  See the

--- a/cbits/nix.cpp
+++ b/cbits/nix.cpp
@@ -22,11 +22,13 @@
     #include <nix/main/shared.hh>
     #include <nix/store/filetransfer.hh>
     #include <nix/store/store-api.hh>
+    #include <nix/store/local-store.hh>
     #include <nix/store/log-store.hh>
 #else
     #include <lix/config.h>
     #include <lix/libmain/shared.hh>
     #include <lix/libstore/filetransfer.hh>
+    #include <lix/libstore/local-store.hh>
     #include <lix/libstore/log-store.hh>
     #include <lix/libstore/store-api.hh>
     #if LIX_POST_2_93
@@ -379,7 +381,9 @@ ffi_return_codes_t dumpLog
 
         StorePath storePath(baseName);
 
-        auto subs = BLOCKON(getDefaultSubstituters());
+        auto subs = dynamic_cast<LocalStore *>(&*store)
+                  ? BLOCKON(getDefaultSubstituters())
+                  : std::list<ref<Store>>();
 
         subs.push_front(store);
 

--- a/cbits/nix.cpp
+++ b/cbits/nix.cpp
@@ -54,7 +54,7 @@ static AsyncIoRoot & aio()
 
 #if CPPNIX || LIX_PRE_2_93
 
-typedef std::shared_ptr<Store> StorePtr
+typedef std::shared_ptr<Store> StorePtr;
 #define OPEN_STORE(X) X == "" ? openStore() : openStore(X)
 #define STORE_REF(X) ref<Store>(X)
 
@@ -68,7 +68,7 @@ static void insertStore(std::string url, StorePtr store) {
 
 static StorePtr lookupStore(std::string url) {
     std::lock_guard<std::mutex> guard(_stores_mutex);
-    return *_stores[url];
+    return _stores.at(url);
 }
 
 #else
@@ -86,7 +86,7 @@ static void insertStore(std::string url, StorePtr store) {
 
 static StorePtr lookupStore(std::string url) {
     auto _stores_(_stores.lock());
-    return (*_stores_)[url];
+    return (*_stores_).at(url);
 }
 
 #endif
@@ -111,16 +111,22 @@ static ref<Store> getStore(std::string const url, bool cached = true)
 extern "C" {
 
 // Must be called once before the server is stated to avoid races
-int initStore(char const * const url)
+ffi_return_codes_t initStore(char const * const url)
 {
     static bool _initDone = false;
-    if (!_initDone) {
-        #if CPPNIX
-        initLibStore(true);
-        #else
-        initNix();
-        #endif
-        _initDone = true;
+
+    try {
+        if (!_initDone) {
+            #if CPPNIX
+            initLibStore(true);
+            #else
+            initNix();
+            #endif
+            _initDone = true;
+        }
+    } catch(const std::exception& e) {
+        std::cout << "Fatal exception in initializing nix: " << e.what() << std::endl;
+        return RETURN_EXCEPTION;
     }
 
     try {
@@ -206,7 +212,7 @@ unsigned long getMaxConnectTimeout()
     #endif
 }
 
-int queryPathFromHashPart
+ffi_return_codes_t queryPathFromHashPart
     ( char const * const url
     , char const * const hashPart
     , struct string * const output
@@ -230,7 +236,7 @@ int queryPathFromHashPart
     return RETURN_OK;
 }
 
-int queryPathInfo
+ffi_return_codes_t queryPathInfo
     ( char const * const url
     , char const * const storePath
     , PathInfo * const output
@@ -289,7 +295,7 @@ void freePathInfo(struct PathInfo * const input)
 }
 
 // TODO: This can be done in Haskell using the `ed25519` package
-int signString
+ffi_return_codes_t signString
     ( char const * const secretKey
     , char const * const message
     , struct string * const output
@@ -311,7 +317,7 @@ int signString
     return RETURN_OK;
 }
 
-bool dumpPath
+ffi_return_codes_t dumpPath
     ( char const * const url
     , char const * const hashPart
     , bool (* const callback)(char const * const data, size_t const size)
@@ -362,7 +368,7 @@ bool dumpPath
     return RETURN_OK;
 }
 
-int dumpLog
+ffi_return_codes_t dumpLog
     ( char const * const url
     , char const * const baseName
     , struct string * const output
@@ -381,6 +387,8 @@ int dumpLog
 
         for (auto & sub : subs) {
             LogStore * logStore = dynamic_cast<LogStore *>(&*sub);
+
+            if (!logStore) continue;
 
             std::optional<std::string> log = BLOCKON(logStore->getBuildLog(storePath));
 

--- a/cbits/nix.cpp
+++ b/cbits/nix.cpp
@@ -21,9 +21,9 @@
 #if CPPNIX
     #include <nix/main/shared.hh>
     #include <nix/store/filetransfer.hh>
-    #include <nix/store/store-api.hh>
     #include <nix/store/local-store.hh>
     #include <nix/store/log-store.hh>
+    #include <nix/store/store-api.hh>
 #else
     #include <lix/config.h>
     #include <lix/libmain/shared.hh>
@@ -321,48 +321,40 @@ ffi_return_codes_t signString
 
 ffi_return_codes_t dumpPath
     ( char const * const url
-    , char const * const hashPart
+    , char const * const storePathStr
     , bool (* const callback)(char const * const data, size_t const size)
     )
 {
     try {
         ref<Store> store = getStore(url);
 
-        std::optional<StorePath> storePath =
-            BLOCKON(store->queryPathFromHashPart(hashPart));
+        auto storePath = store->parseStorePath(storePathStr);
 
-        if (storePath.has_value()) {
-            LambdaSink sink([=](std::string_view v) {
-                bool succeeded = (*callback)(v.data(), v.size());
+        LambdaSink sink([=](std::string_view v) {
+            bool succeeded = (*callback)(v.data(), v.size());
 
-                if (!succeeded) {
-                    // We don't really care about the error message.  The only
-                    // reason for throwing an exception here is that this is the
-                    // only way that a Nix sink can exit early.
-                    throw std::runtime_error("");
-                }
-            });
-
-            try {
-                #if CPPNIX
-                store->narFromPath(storePath.value(), sink);
-                #elif LIX_PRE_2_93
-                sink << store->narFromPath(storePath.value());
-                #elif ! defined(LIX_MAJOR) || LIX_MAJOR <= 2 && LIX_MINOR < 94
-                aio().blockOn(store->narFromPath(storePath.value()))->drainInto(sink);
-                #else
-                aio().blockOn(aio().blockOn(store->narFromPath(storePath.value()))->drainInto(sink));
-                #endif
-            } catch (const std::runtime_error & e) {
-                // Intentionally do nothing.  We're only using the exception as a
-                // short-circuiting mechanism.
+            if (!succeeded) {
+                // We don't really care about the error message.  The only
+                // reason for throwing an exception here is that this is the
+                // only way that a Nix sink can exit early.
+                throw std::runtime_error("");
             }
+        });
 
-            return RETURN_OK;
-        } else {
-            return RETURN_FAIL;
+        try {
+            #if CPPNIX
+            store->narFromPath(storePath, sink);
+            #elif LIX_PRE_2_93
+            sink << store->narFromPath(storePath);
+            #elif ! defined(LIX_MAJOR) || LIX_MAJOR <= 2 && LIX_MINOR < 94
+            aio().blockOn(store->narFromPath(storePath))->drainInto(sink);
+            #else
+            aio().blockOn(aio().blockOn(store->narFromPath(storePath))->drainInto(sink));
+            #endif
+        } catch (const std::runtime_error & e) {
+            // Intentionally do nothing.  We're only using the exception as a
+            // short-circuiting mechanism.
         }
-
     } catch(const std::exception& e) {
         std::cout << "Exception in 'dumpPath': " << e.what() << std::endl;
         return RETURN_EXCEPTION;

--- a/cbits/nix.cpp
+++ b/cbits/nix.cpp
@@ -1,5 +1,9 @@
 #include <cstddef>
 #include <cstdlib>
+#include <iostream>
+#include <map>
+#include <mutex>
+#include <stdexcept>
 
 #ifndef LIX
     #define CPPNIX 1
@@ -15,14 +19,16 @@
 #endif
 
 #if CPPNIX
+    #include <nix/main/shared.hh>
+    #include <nix/store/filetransfer.hh>
     #include <nix/store/store-api.hh>
     #include <nix/store/log-store.hh>
-    #include <nix/main/shared.hh>
 #else
     #include <lix/config.h>
-    #include <lix/libstore/store-api.hh>
-    #include <lix/libstore/log-store.hh>
     #include <lix/libmain/shared.hh>
+    #include <lix/libstore/filetransfer.hh>
+    #include <lix/libstore/log-store.hh>
+    #include <lix/libstore/store-api.hh>
     #if LIX_POST_2_93
         #include <lix/libutil/async.hh>
     #endif
@@ -46,49 +52,84 @@ static AsyncIoRoot & aio()
 }
 #endif
 
-// Copied from:
-//
-// https://github.com/NixOS/nix/blob/2.8.1/perl/lib/Nix/Store.xs#L24-L37
-static ref<Store> getStore(std::string const uri = "")
-{
-#if CPPNIX
-    static std::shared_ptr<Store> _store;
+#if CPPNIX || LIX_PRE_2_93
 
-    if (!_store) {
-        initLibStore(true);
-        _store = uri == "" ? openStore() : openStore(uri);
-    }
-    return ref<Store>(_store);
-#elif LIX_PRE_2_93
-    static std::shared_ptr<Store> _store;
+typedef std::shared_ptr<Store> StorePtr
+#define OPEN_STORE(X) X == "" ? openStore() : openStore(X)
+#define STORE_REF(X) ref<Store>(X)
 
-    if (!_store) {
-        initNix();
-        _store = uri == "" ? openStore() : openStore(uri);
-    }
-    return ref<Store>(_store);
+std::mutex _stores_mutex;
+static std::map<std::string, StorePtr> _stores;
+
+static void insertStore(std::string url, StorePtr store) {
+    std::lock_guard<std::mutex> guard(_stores_mutex);
+    _stores.insert({url,store});
+}
+
+static StorePtr lookupStore(std::string url) {
+    std::lock_guard<std::mutex> guard(_stores_mutex);
+    return *_stores[url];
+}
+
 #else
-    static std::optional<ref<Store>> _store;
 
-    if (!_store) {
-        initNix();
-        _store = aio().blockOn(uri == "" ? openStore() : openStore(uri));
-    }
-    return *_store;
+typedef std::optional<ref<Store>> StorePtr;
+#define OPEN_STORE(X) aio().blockOn(X == "" ? openStore() : openStore(X))
+#define STORE_REF(X) *X
+
+static Sync<std::map<std::string, StorePtr>> _stores;
+
+static void insertStore(std::string url, StorePtr store) {
+    auto _stores_(_stores.lock());
+    (*_stores_).insert({url,store});
+}
+
+static StorePtr lookupStore(std::string url) {
+    auto _stores_(_stores.lock());
+    return (*_stores_)[url];
+}
+
 #endif
+
+// Based on: https://github.com/NixOS/nix/blob/2.8.1/perl/lib/Nix/Store.xs#L24-L37
+// with allowance for multiple stores
+static ref<Store> getStore(std::string const url, bool cached = true)
+{
+    StorePtr store;
+
+    if (!cached) {
+        store = OPEN_STORE(url);
+        insertStore(url, store);
+    } else {
+        // We know this exists from the Haskell side
+        store = lookupStore(url);
+    }
+
+    return STORE_REF(store);
 }
 
 extern "C" {
 
 // Must be called once before the server is stated to avoid races
-void initStore()
+int initStore(char const * const url)
 {
-    getStore();
-}
+    static bool _initDone = false;
+    if (!_initDone) {
+        #if CPPNIX
+        initLibStore(true);
+        #else
+        initNix();
+        #endif
+        _initDone = true;
+    }
 
-void initStoreUri(char const * const uri)
-{
-    getStore(uri);
+    try {
+        getStore(url, false);
+    } catch(const std::exception& e) {
+        std::cout << "Exception in 'initStore': " << e.what() << std::endl;
+        return RETURN_FAIL;
+    }
+    return RETURN_OK;
 }
 
 void freeString(struct string * const input)
@@ -154,62 +195,89 @@ void getStoreDir(struct string * const output)
     copyString(settings.nixStore, output);
 }
 
-void queryPathFromHashPart
-    ( char const * const hashPart
+unsigned long getMaxConnectTimeout()
+{
+    #if CPPNIX
+    return fileTransferSettings.connectTimeout;
+    #elif ! defined(LIX_MAJOR) || LIX_MAJOR <= 2 && LIX_MINOR < 94
+    return fileTransferSettings.connectTimeout.get();
+    #else
+    return fileTransferSettings.maxConnectTimeout.get();
+    #endif
+}
+
+int queryPathFromHashPart
+    ( char const * const url
+    , char const * const hashPart
     , struct string * const output
     )
 {
-    ref<Store> store = getStore();
+    try {
+        ref<Store> store = getStore(url);
 
-    std::optional<StorePath> path = BLOCKON(store->queryPathFromHashPart(hashPart));
+        std::optional<StorePath> path = BLOCKON(store->queryPathFromHashPart(hashPart));
 
-    if (path.has_value()) {
-        copyString(store->printStorePath(path.value()), output);
-    } else {
-        *output = emptyString;
+        if (path.has_value()) {
+            copyString(store->printStorePath(path.value()), output);
+        } else {
+            *output = emptyString;
+        }
+
+    } catch(const std::exception& e) {
+        std::cout << "Exception in 'queryPathFromHashPart': " << e.what() << std::endl;
+        return RETURN_EXCEPTION;
     }
+    return RETURN_OK;
 }
 
-void queryPathInfo
-    ( char const * const storePath
+int queryPathInfo
+    ( char const * const url
+    , char const * const storePath
     , PathInfo * const output
     )
 {
-    ref<Store> store = getStore();
+    try {
+        ref<Store> store = getStore(url);
 
-    ref<ValidPathInfo const> const validPathInfo =
-        BLOCKON(store->queryPathInfo(store->parseStorePath(storePath)));
+        ref<ValidPathInfo const> const validPathInfo =
+            BLOCKON(store->queryPathInfo(store->parseStorePath(storePath)));
 
-    std::optional<StorePath const> const deriver = validPathInfo->deriver;
+        std::optional<StorePath const> const deriver = validPathInfo->deriver;
 
-    if (deriver.has_value()) {
-        copyString(store->printStorePath(deriver.value()), &output->deriver);
-    } else {
-        output->deriver = emptyString;
-    };
+        if (deriver.has_value()) {
+            copyString(store->printStorePath(deriver.value()), &output->deriver);
+        } else {
+            output->deriver = emptyString;
+        };
 
-#if CPPNIX
-    copyString(validPathInfo->narHash.to_string(nix::HashFormat::Nix32, true), &output->narHash);
-#else
-    copyString(validPathInfo->narHash.to_string(nix::Base::Base32, true), &output->narHash);
-#endif
+        #if CPPNIX
+        copyString(validPathInfo->narHash.to_string(nix::HashFormat::Nix32, true), &output->narHash);
+        #else
+        copyString(validPathInfo->narHash.to_string(nix::Base::Base32, true), &output->narHash);
+        #endif
 
-    output->narSize = validPathInfo->narSize;
+        output->narSize = validPathInfo->narSize;
 
-    std::vector<std::string> references(validPathInfo->references.size());
+        std::vector<std::string> references(validPathInfo->references.size());
 
-    std::transform(
-        validPathInfo->references.begin(),
-        validPathInfo->references.end(),
-        references.begin(),
-        [=](StorePath storePath) { return store->printStorePath(storePath); }
-    );
+        std::transform(
+            validPathInfo->references.begin(),
+            validPathInfo->references.end(),
+            references.begin(),
+            [=](StorePath storePath) { return store->printStorePath(storePath); }
+        );
 
-    copyStrings(references, &output->references);
+        copyStrings(references, &output->references);
 
-    std::vector<std::string> sigs(validPathInfo->sigs.begin(), validPathInfo->sigs.end());
+        std::vector<std::string> sigs(validPathInfo->sigs.begin(), validPathInfo->sigs.end());
 
-    copyStrings(sigs, &output->sigs);
+        copyStrings(sigs, &output->sigs);
+
+    } catch(const std::exception& e) {
+        std::cout << "Exception in 'queryPathInfo': " << e.what() << std::endl;
+        return RETURN_EXCEPTION;
+    }
+    return RETURN_OK;
 }
 
 void freePathInfo(struct PathInfo * const input)
@@ -221,83 +289,110 @@ void freePathInfo(struct PathInfo * const input)
 }
 
 // TODO: This can be done in Haskell using the `ed25519` package
-void signString
+int signString
     ( char const * const secretKey
     , char const * const message
     , struct string * const output
     )
 {
-#if ! defined(LIX_MAJOR) || LIX_MAJOR <= 2 && LIX_MINOR < 94
-    std::string signature = SecretKey(secretKey).signDetached(message);
-#else
-    std::string signature = SecretKey::parse(secretKey).signDetached(message);
-#endif
+    try {
+        #if ! defined(LIX_MAJOR) || LIX_MAJOR <= 2 && LIX_MINOR < 94
+        std::string signature = SecretKey(secretKey).signDetached(message);
+        #else
+        std::string signature = SecretKey::parse(secretKey).signDetached(message);
+        #endif
 
-    copyString(signature, output);
+        copyString(signature, output);
+
+    } catch(const std::exception& e) {
+        std::cout << "Exception in 'signStrings': " << e.what() << std::endl;
+        return RETURN_EXCEPTION;
+    }
+    return RETURN_OK;
 }
 
 bool dumpPath
-    ( char const * const hashPart
+    ( char const * const url
+    , char const * const hashPart
     , bool (* const callback)(char const * const data, size_t const size)
     )
 {
-    ref<Store> store = getStore();
+    try {
+        ref<Store> store = getStore(url);
 
-    std::optional<StorePath> storePath =
-        BLOCKON(store->queryPathFromHashPart(hashPart));
+        std::optional<StorePath> storePath =
+            BLOCKON(store->queryPathFromHashPart(hashPart));
 
-    if (storePath.has_value()) {
-        LambdaSink sink([=](std::string_view v) {
-            bool succeeded = (*callback)(v.data(), v.size());
+        if (storePath.has_value()) {
+            LambdaSink sink([=](std::string_view v) {
+                bool succeeded = (*callback)(v.data(), v.size());
 
-            if (!succeeded) {
-                // We don't really care about the error message.  The only
-                // reason for throwing an exception here is that this is the
-                // only way that a Nix sink can exit early.
-                throw std::runtime_error("");
+                if (!succeeded) {
+                    // We don't really care about the error message.  The only
+                    // reason for throwing an exception here is that this is the
+                    // only way that a Nix sink can exit early.
+                    throw std::runtime_error("");
+                }
+            });
+
+            try {
+                #if CPPNIX
+                store->narFromPath(storePath.value(), sink);
+                #elif LIX_PRE_2_93
+                sink << store->narFromPath(storePath.value());
+                #elif ! defined(LIX_MAJOR) || LIX_MAJOR <= 2 && LIX_MINOR < 94
+                aio().blockOn(store->narFromPath(storePath.value()))->drainInto(sink);
+                #else
+                aio().blockOn(aio().blockOn(store->narFromPath(storePath.value()))->drainInto(sink));
+                #endif
+            } catch (const std::runtime_error & e) {
+                // Intentionally do nothing.  We're only using the exception as a
+                // short-circuiting mechanism.
             }
-        });
 
-        try {
-#if CPPNIX
-            store->narFromPath(storePath.value(), sink);
-#elif LIX_PRE_2_93
-            sink << store->narFromPath(storePath.value());
-#elif ! defined(LIX_MAJOR) || LIX_MAJOR <= 2 && LIX_MINOR < 94
-            aio().blockOn(store->narFromPath(storePath.value()))->drainInto(sink);
-#else
-            aio().blockOn(aio().blockOn(store->narFromPath(storePath.value()))->drainInto(sink));
-#endif
-        } catch (const std::runtime_error & e) {
-            // Intentionally do nothing.  We're only using the exception as a
-            // short-circuiting mechanism.
+            return RETURN_OK;
+        } else {
+            return RETURN_FAIL;
         }
 
-        return true;
-    } else {
-        return false;
+    } catch(const std::exception& e) {
+        std::cout << "Exception in 'dumpPath': " << e.what() << std::endl;
+        return RETURN_EXCEPTION;
     }
+    return RETURN_OK;
 }
 
-void dumpLog(char const * const baseName, struct string * const output) {
-    ref<Store> store = getStore();
+int dumpLog
+    ( char const * const url
+    , char const * const baseName
+    , struct string * const output
+    )
+{
+    try {
+        ref<Store> store = getStore(url);
 
-    StorePath storePath(baseName);
+        StorePath storePath(baseName);
 
-    auto subs = BLOCKON(getDefaultSubstituters());
+        auto subs = BLOCKON(getDefaultSubstituters());
 
-    subs.push_front(store);
+        subs.push_front(store);
 
-    *output = emptyString;
+        *output = emptyString;
 
-    for (auto & sub : subs) {
-        LogStore * logStore = dynamic_cast<LogStore *>(&*sub);
+        for (auto & sub : subs) {
+            LogStore * logStore = dynamic_cast<LogStore *>(&*sub);
 
-        std::optional<std::string> log = BLOCKON(logStore->getBuildLog(storePath));
+            std::optional<std::string> log = BLOCKON(logStore->getBuildLog(storePath));
 
-        if (log.has_value()) {
-            copyString(log.value(), output);
+            if (log.has_value()) {
+                copyString(log.value(), output);
+            }
         }
+
+        return RETURN_OK;
+    } catch(const std::exception& e) {
+        std::cout << "Exception in 'dumpLog': '" << e.what() << std::endl;
+        return RETURN_EXCEPTION;
     }
 }
 

--- a/cbits/nix.hh
+++ b/cbits/nix.hh
@@ -20,3 +20,9 @@ struct PathInfo {
     struct strings references;
     struct strings sigs;
 };
+
+typedef enum {
+    RETURN_OK        = 0,
+    RETURN_FAIL      = 1,
+    RETURN_EXCEPTION = 2,
+} ffi_return_codes_t;

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "flake-compat": {
       "flake": false,
       "locked": {
-        "lastModified": 1761588595,
-        "narHash": "sha256-XKUZz9zewJNUj46b4AJdiRZJAvSZ0Dqj2BNfXvFlJC4=",
+        "lastModified": 1767039857,
+        "narHash": "sha256-vNpUSpF5Nuw8xvDLj2KCwwksIbjua2LZCqhV1LNRDns=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "f387cd2afec9419c8ee37694406ca490c3f34ee5",
+        "rev": "5edf11c44bc78a0d334f6334cdaf7d60d732daab",
         "type": "github"
       },
       "original": {
@@ -401,16 +401,16 @@
     },
     "nixpkgs_6": {
       "locked": {
-        "lastModified": 1764560356,
-        "narHash": "sha256-M5aFEFPppI4UhdOxwdmceJ9bDJC4T6C6CzCK1E2FZyo=",
+        "lastModified": 1771903837,
+        "narHash": "sha256-sdaqdnsQCv3iifzxwB22tUwN/fSHoN7j2myFW5EIkGk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6c8f0cca84510cc79e09ea99a299c9bc17d03cb6",
+        "rev": "e764fc9a405871f1f6ca3d1394fb422e0a0c3951",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-25.05",
+        "ref": "nixos-25.11",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,6 @@
 {
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?ref=nixos-25.05";
+    nixpkgs.url = "github:NixOS/nixpkgs?ref=nixos-25.11";
 
     lix-2_92_3.url = "git+https://git.lix.systems/lix-project/lix?ref=2.92.3";
     lix-2_93_3.url = "git+https://git.lix.systems/lix-project/lix?ref=2.93.3";
@@ -17,7 +17,7 @@
   outputs =
     { nixpkgs, utils, ... }@inputs:
     let
-      compiler = "ghc984";
+      compiler = "ghc9103";
 
       patches = {
         lix = {
@@ -85,10 +85,16 @@
                           ++ final.lib.optional (nix.pname == "lix") "-flix";
 
                         executableSystemDepends = (old.executableSystemDepends or [ ]) ++ [
-                          patchedNix
+                          patchedNix.dev
                           final.boost.dev
+                          final.libcpuid
+                          final.libseccomp
                         ] ++ final.lib.optionals (nix.pname == "lix" && builtins.compareVersions nix.version "2.93.0" >= 0) [
+                          final.aws-sdk-cpp
                           final.capnproto
+                        ] ++ final.lib.optionals (nix.pname == "nix") [
+                          final.libblake3
+                          final.libsodium
                         ];
 
                         passthru = (old.passthru or { }) // {

--- a/nix-serve-ng.cabal
+++ b/nix-serve-ng.cabal
@@ -21,7 +21,8 @@ executable nix-serve
 
     main-is:          Main.hs
 
-    other-modules:    Nix
+    other-modules:  , NixFFI
+                    , Nix
                     , Options
 
     -- https://nixos.org/manual/nix/stable/installation/supported-platforms.html
@@ -43,17 +44,26 @@ executable nix-serve
 
     cxx-options:      -std=c++20
 
-    build-depends:    base < 5
+    build-depends:  , base < 5
+                    , aeson
+                    , async
                     , base16 >= 1.0
                     , base32
                     , bytestring
                     , charset
+                    , containers
                     , http-types
                     , managed
                     , megaparsec
                     , mtl
                     , network
                     , optparse-applicative
+                    , safe-exceptions
+                    , text
+                    , time
+                    , transformers
+                    , unliftio
+                    , uri-bytestring
                     , vector
                     , wai
                     , wai-extra
@@ -77,9 +87,28 @@ executable nix-serve
     else
       buildable:      False
 
-    default-language: Haskell2010
+    default-language: GHC2024
 
-    ghc-options:      -Wall -threaded -O2 -rtsopts
+    default-extensions:
+      ApplicativeDo
+      BlockArguments
+      DeriveAnyClass
+      DerivingStrategies
+      DuplicateRecordFields
+      GeneralizedNewtypeDeriving
+      ImportQualifiedPost
+      LambdaCase
+      MultiWayIf
+      NamedFieldPuns
+      OverloadedRecordDot
+      OverloadedStrings
+      TypeApplications
+      TupleSections
+
+    ghc-options:  -Wall -threaded -O2 -rtsopts
+                  -- Is there another way to get a sensible max
+                  -- for setNumCapabilities?
+                  "-with-rtsopts=-N"
 
 benchmark benchmark
     hs-source-dirs:   benchmark

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -110,9 +110,6 @@ makeApplication opts request respond = do
             done response
 
     let queryPathInfoFromHashPart hashPart = do
-          -- TODO: Maybe we should cancel the queries that lose the race?
-          -- Choosing not to becasue it's possible it may invalidate connections
-          -- for some store types, and it's hard to test.
           let raceQuery = mapRace (flip Nix.queryPathInfoFromHashPart hashPart)
           result <- liftIO $ findJustM raceQuery (Nix.priorityGroups opts.stores)
 

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -12,15 +12,17 @@ import Numeric.Natural (Natural)
 import Options (Options(..), Socket(..), SSL(..), LogFormat(..))
 
 import qualified Control.Concurrent.Async             as Async
-import qualified Data.List.NonEmpty                   as NonEmpty
 import qualified Control.Monad                        as Monad
 import qualified Control.Monad.Except                 as Except
+import qualified Data.Aeson                           as Aeson
 import qualified Data.ByteString                      as ByteString
 import qualified Data.ByteString.Char8                as ByteString.Char8
 import qualified Data.ByteString.Builder              as Builder
 import qualified Data.ByteString.Lazy                 as ByteString.Lazy
 import qualified Data.CharSet.ByteSet                 as ByteSet
 import qualified Data.List                            as List
+import qualified Data.List.NonEmpty                   as NonEmpty
+import qualified Data.Text.Encoding                   as Text
 import qualified Data.Vector                          as Vector
 import qualified Data.Void                            as Void
 import qualified Network.HTTP.Types                   as Types
@@ -115,7 +117,9 @@ makeApplication opts request respond = do
           result <- liftIO $ findJustM raceQuery (Nix.priorityGroups opts.stores)
 
           let logged (store, (storePath, pathInfo)) = do
-                  liftIO $ Nix.logMsg Debug Blue store "Using" []
+                  let toValue = Aeson.toJSON . Text.decodeUtf8Lenient
+                  liftIO $ Nix.logMsg Debug Blue store "Found" [ ("hashPart", toValue hashPart)
+                                                               , ("storePath", toValue storePath) ]
                   pure (store, storePath, pathInfo)
 
           maybe noSuchPath logged result

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -14,7 +14,6 @@ import Options (Options(..), Socket(..), SSL(..), LogFormat(..))
 import qualified Control.Concurrent.Async             as Async
 import qualified Control.Monad                        as Monad
 import qualified Control.Monad.Except                 as Except
-import qualified Data.Aeson                           as Aeson
 import qualified Data.ByteString                      as ByteString
 import qualified Data.ByteString.Char8                as ByteString.Char8
 import qualified Data.ByteString.Builder              as Builder
@@ -35,7 +34,7 @@ import qualified Options
 import qualified Options.Applicative                  as Options
 import qualified System.Environment                   as Environment
 
-import Nix (Stores, PathInfo(..), LogLevel(..), Color(..))
+import Nix (Stores, PathInfo(..), LogLevel(..), Color(..), (.=))
 import qualified Nix
 
 data ApplicationOptions = ApplicationOptions
@@ -113,10 +112,11 @@ makeApplication opts request respond = do
           let raceQuery = mapRace (flip Nix.queryPathInfoFromHashPart hashPart)
           result <- liftIO $ findJustM raceQuery (Nix.priorityGroups opts.stores)
 
-          let logged (store, (storePath, pathInfo)) = do
-                  let toValue = Aeson.toJSON . Text.decodeUtf8Lenient
-                  liftIO $ Nix.logMsg Debug Blue store "Found" [ ("hashPart", toValue hashPart)
-                                                               , ("storePath", toValue storePath) ]
+          let logged (store, (storePath, pathInfo)) = liftIO do
+                  Nix.logMsg Debug Blue store "Found" $ mconcat
+                      [ "hashPart"  .= Text.decodeUtf8Lenient hashPart
+                      , "storePath" .= Text.decodeUtf8Lenient storePath
+                      ]
                   pure (store, storePath, pathInfo)
 
           maybe noSuchPath logged result

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -33,7 +33,7 @@ import qualified Options
 import qualified Options.Applicative                  as Options
 import qualified System.Environment                   as Environment
 
-import Nix (Stores, PathInfo(..), Color(..))
+import Nix (Stores, PathInfo(..), LogLevel(..), Color(..))
 import qualified Nix
 
 data ApplicationOptions = ApplicationOptions
@@ -115,7 +115,7 @@ makeApplication opts request respond = do
           result <- liftIO $ findJustM raceQuery (Nix.priorityGroups opts.stores)
 
           let logged (store, (storePath, pathInfo)) = do
-                  liftIO $ Nix.logMsg Blue store "Using" []
+                  liftIO $ Nix.logMsg Debug Blue store "Using" []
                   pure (store, storePath, pathInfo)
 
           maybe noSuchPath logged result

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -325,6 +325,8 @@ findJustM act = go
   go []     = pure Nothing
   go (x:xs) = act x >>= maybe (go xs) (pure . pure)
 
+-- NOTE: This intentionally does not cancel the other asyncs
+-- so it should only be used with short lived actions.
 mapRace :: (a -> IO (Maybe b)) -> [a] -> IO (Maybe (a, b))
 mapRace _   []  = pure Nothing
 mapRace act [x] = fmap (x,) <$> act x

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -240,7 +240,7 @@ makeApplication opts request respond = do
                 Monad.unless (validHashPart hashPart) do
                     invalidPath
 
-                (store, _, PathInfo{narHash}) <- queryPathInfoFromHashPart hashPart
+                (store, storePath, PathInfo{narHash}) <- queryPathInfoFromHashPart hashPart
 
                 Monad.unless (all (narHash ==) maybeExpectedNarHash) do
                     let headers = [ ("Content-Type", "text/plain") ]
@@ -256,7 +256,7 @@ makeApplication opts request respond = do
 
                     done response
 
-                let streamingBody write flush = Nix.dumpPath store hashPart callback
+                let streamingBody write flush = Nix.dumpPath store storePath callback
                       where callback builder = write builder >> flush
 
                 let headers = [ ("Content-Type", "text/plain") ]

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -1,8 +1,4 @@
-{-# LANGUAGE BlockArguments    #-}
-{-# LANGUAGE MultiWayIf        #-}
-{-# LANGUAGE NamedFieldPuns    #-}
-{-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE RecordWildCards   #-}
+{-# LANGUAGE RecordWildCards #-}
 
 module Main where
 
@@ -12,11 +8,11 @@ import Data.CharSet.ByteSet (ByteSet(..))
 import Data.Function ((&))
 import Network.Socket (SockAddr(..))
 import Network.Wai (Application)
-import Nix (NoSuchPath(..), PathInfo(..))
 import Numeric.Natural (Natural)
 import Options (Options(..), Socket(..), SSL(..), LogFormat(..))
 
-import qualified Control.Exception                    as Exception
+import qualified Control.Concurrent.Async             as Async
+import qualified Data.List.NonEmpty                   as NonEmpty
 import qualified Control.Monad                        as Monad
 import qualified Control.Monad.Except                 as Except
 import qualified Data.ByteString                      as ByteString
@@ -24,6 +20,7 @@ import qualified Data.ByteString.Char8                as ByteString.Char8
 import qualified Data.ByteString.Builder              as Builder
 import qualified Data.ByteString.Lazy                 as ByteString.Lazy
 import qualified Data.CharSet.ByteSet                 as ByteSet
+import qualified Data.List                            as List
 import qualified Data.Vector                          as Vector
 import qualified Data.Void                            as Void
 import qualified Network.HTTP.Types                   as Types
@@ -32,15 +29,19 @@ import qualified Network.Wai                          as Wai
 import qualified Network.Wai.Handler.Warp             as Warp
 import qualified Network.Wai.Handler.WarpTLS          as WarpTLS
 import qualified Network.Wai.Middleware.RequestLogger as RequestLogger
-import qualified Nix
 import qualified Options
 import qualified Options.Applicative                  as Options
 import qualified System.Environment                   as Environment
 
+import Nix (Stores, PathInfo(..), Color(..))
+import qualified Nix
+
 data ApplicationOptions = ApplicationOptions
     { priority       :: Integer
     , storeDirectory :: ByteString
+    , stores         :: Stores
     , secretKey      :: Maybe ByteString
+    , logFormat      :: LogFormat
     }
 
 -- https://github.com/NixOS/nix/blob/2.8.1/src/libutil/hash.cc#L83-L84
@@ -58,12 +59,14 @@ validHashPart :: ByteString -> Bool
 validHashPart hash = ByteString.all (`ByteSet.member` validHashPartBytes) hash
 
 makeApplication :: ApplicationOptions -> Application
-makeApplication ApplicationOptions{..} request respond = do
-    let stripStore = ByteString.stripPrefix (storeDirectory <> "/")
+makeApplication opts request respond = do
+
+    let stripStore = ByteString.stripPrefix (opts.storeDirectory <> "/")
 
     let done = Except.throwError
 
-    let internalError message = do
+    let internalError :: Builder.Builder -> Except.ExceptT Wai.Response IO a
+        internalError message = do
             let headers = [ ("Content-Type", "text/plain") ]
 
             let builder = "Internal server error: " <> message <> ".\n"
@@ -76,7 +79,8 @@ makeApplication ApplicationOptions{..} request respond = do
 
             done response
 
-    let noSuchPath = do
+    let noSuchPath :: Except.ExceptT Wai.Response IO a
+        noSuchPath = do
             let headers = [ ("Content-Type", "text/plain") ]
 
             let builder = "No such path.\n"
@@ -89,7 +93,8 @@ makeApplication ApplicationOptions{..} request respond = do
 
             done response
 
-    let invalidPath = do
+    let invalidPath :: Except.ExceptT Wai.Response IO a
+        invalidPath = do
             let headers = [ ("Content-Type", "text/plain") ]
 
             let builder = "Invalid path.\n"
@@ -102,6 +107,19 @@ makeApplication ApplicationOptions{..} request respond = do
 
             done response
 
+    let queryPathInfoFromHashPart hashPart = do
+          -- TODO: Maybe we should cancel the queries that lose the race?
+          -- Choosing not to becasue it's possible it may invalidate connections
+          -- for some store types, and it's hard to test.
+          let raceQuery = mapRace (flip Nix.queryPathInfoFromHashPart hashPart)
+          result <- liftIO $ findJustM raceQuery (Nix.priorityGroups opts.stores)
+
+          let logged (store, (storePath, pathInfo)) = do
+                  liftIO $ Nix.logMsg Blue store "Using" []
+                  pure (store, storePath, pathInfo)
+
+          maybe noSuchPath logged result
+
     result <- Except.runExceptT do
         let rawPath = Wai.rawPathInfo request
 
@@ -110,21 +128,15 @@ makeApplication ApplicationOptions{..} request respond = do
                 Monad.unless (ByteString.length hashPart == 32 && validHashPart hashPart) do
                     invalidPath
 
-                maybeStorePath <- liftIO (Nix.queryPathFromHashPart hashPart)
+                (_, storePath, pathInfo) <- queryPathInfoFromHashPart hashPart
 
-                storePath <- case maybeStorePath of
-                    Left NoSuchPath -> noSuchPath
-                    Right storePath -> return storePath
-
-                pathInfo@PathInfo{..} <- liftIO (Nix.queryPathInfo storePath)
-
-                narHash2 <- case ByteString.stripPrefix "sha256:" narHash of
+                narHash2 <- case ByteString.stripPrefix "sha256:" pathInfo.narHash of
                     Nothing -> do
                         internalError "NAR hash missing sha256: prefix"
                     Just narHash2 -> do
                         return narHash2
 
-                referenceNames <- case traverse stripStore references of
+                referenceNames <- case traverse stripStore pathInfo.references of
                     Nothing -> do
                         internalError "references missing store directory prefix"
                     Just names -> do
@@ -139,7 +151,7 @@ makeApplication ApplicationOptions{..} request respond = do
                             mempty
 
                 deriverBuilder <-
-                    case deriver of
+                    case pathInfo.deriver of
                         Just d ->
                             case stripStore d of
                                 Just name ->
@@ -160,14 +172,14 @@ makeApplication ApplicationOptions{..} request respond = do
                     Just builder -> do
                         return (ByteString.Lazy.toStrict (Builder.toLazyByteString builder))
 
-                signatures <- case secretKey of
+                signatures <- case opts.secretKey of
                     Just key -> do
                         signature <- liftIO (Nix.signString key fingerprint)
 
                         return (Vector.singleton signature)
 
                     Nothing -> do
-                        return sigs
+                        return pathInfo.sigs
 
                 let buildSignature signature =
                         "Sig: " <> Builder.byteString signature <> "\n"
@@ -180,9 +192,9 @@ makeApplication ApplicationOptions{..} request respond = do
                         <>  "-"
                         <>  Builder.byteString narHash2
                         <>  ".nar\nCompression: none\nNarHash: "
-                        <>  Builder.byteString narHash
+                        <>  Builder.byteString pathInfo.narHash
                         <>  "\nNarSize: "
-                        <>  Builder.word64Dec narSize
+                        <>  Builder.word64Dec pathInfo.narSize
                         <>  "\n"
                         <>  referencesBuilder
                         <>  deriverBuilder
@@ -228,13 +240,7 @@ makeApplication ApplicationOptions{..} request respond = do
                 Monad.unless (validHashPart hashPart) do
                     invalidPath
 
-                maybeStorePath <- liftIO (Nix.queryPathFromHashPart hashPart)
-
-                storePath <- case maybeStorePath of
-                    Left  NoSuchPath-> noSuchPath
-                    Right storePath -> return storePath
-
-                PathInfo{ narHash } <- liftIO (Nix.queryPathInfo storePath)
+                (store, _, PathInfo{narHash}) <- queryPathInfoFromHashPart hashPart
 
                 Monad.unless (all (narHash ==) maybeExpectedNarHash) do
                     let headers = [ ("Content-Type", "text/plain") ]
@@ -250,16 +256,8 @@ makeApplication ApplicationOptions{..} request respond = do
 
                     done response
 
-                let streamingBody write flush = do
-                       result <- Nix.dumpPath hashPart callback
-
-                       case result of
-                           Left  exception -> Exception.throwIO exception
-                           Right x         -> return x
-                      where
-                        callback builder = do
-                            () <- write builder
-                            flush
+                let streamingBody write flush = Nix.dumpPath store hashPart callback
+                      where callback builder = write builder >> flush
 
                 let headers = [ ("Content-Type", "text/plain") ]
 
@@ -274,7 +272,10 @@ makeApplication ApplicationOptions{..} request respond = do
                 Monad.unless (ByteString.length hashPart == 32 && validHashPart hashPart) do
                     invalidPath
 
-                maybeBytes <- liftIO (Nix.dumpLog suffix)
+                -- TODO: This could be split into a path query / dump like we do for nars
+                -- so we can race the queries, but this isn't a hot path operation
+                -- so there is less of a benefit.
+                maybeBytes <- liftIO $ findJustM (flip Nix.dumpLog suffix) (Nix.storeList opts.stores)
 
                 bytes <- case maybeBytes of
                     Nothing    -> noSuchPath
@@ -294,9 +295,9 @@ makeApplication ApplicationOptions{..} request respond = do
 
                 let builder =
                             "StoreDir: "
-                        <>  Builder.byteString storeDirectory
+                        <>  Builder.byteString opts.storeDirectory
                         <>  "\nWantMassQuery: 1\nPriority: "
-                        <>  Builder.integerDec priority
+                        <>  Builder.integerDec opts.priority
                         <>  "\n"
 
                 let response =
@@ -318,6 +319,25 @@ makeApplication ApplicationOptions{..} request respond = do
         Left response -> respond response
         Right void    -> Void.absurd void
 
+findJustM :: Monad m => (a -> m (Maybe b)) -> [a] -> m (Maybe b)
+findJustM act = go
+  where
+  go []     = pure Nothing
+  go (x:xs) = act x >>= maybe (go xs) (pure . pure)
+
+mapRace :: (a -> IO (Maybe b)) -> [a] -> IO (Maybe (a, b))
+mapRace _   []  = pure Nothing
+mapRace act [x] = fmap (x,) <$> act x
+mapRace act xs  = mapM (\x -> (fmap . fmap . fmap) (x,) . Async.async $ act x) xs >>= go
+  where
+  -- This use of `List.delete` is O(n^2) in the the length of xs,
+  -- but for relatively small xs, it should still be cheap
+  -- relative to the cost of `act`
+  go [] = pure Nothing
+  go as = do
+    (a, v) <- Async.waitAny as
+    maybe (go $ List.delete a as) (pure . pure) v
+
 toSocket :: Natural -> FilePath -> IO Socket.Socket
 toSocket backlog path = do
     let family = Socket.AF_UNIX
@@ -338,10 +358,9 @@ readSecretKey = fmap ByteString.Char8.strip . ByteString.readFile
 
 main :: IO ()
 main = do
-    options@Options{ priority, store, timeout, logFormat } <- do
-        Options.execParser Options.parserInfo
+    opts@Options{priority, logFormat} <- Options.execParser Options.parserInfo
 
-    maybe Nix.initStore Nix.initStoreUri store
+    stores <- Nix.initStores opts.retryTimeout opts.cores logFormat $ NonEmpty.toList opts.storeURLs
 
     storeDirectory <- Nix.getStoreDir
 
@@ -362,9 +381,9 @@ main = do
 
     let sharedSettings =
             Warp.defaultSettings
-                & Warp.setTimeout (fromIntegral timeout)
+                & Warp.setTimeout (fromIntegral opts.timeout)
 
-    case options of
+    case opts of
         Options{ ssl = Disabled, socket = TCP{ host, port } } -> do
             let settings =
                     sharedSettings

--- a/src/Nix.hs
+++ b/src/Nix.hs
@@ -40,19 +40,19 @@ import System.IO (stdout)
 import URI.ByteString (URIRef(..), Scheme(schemeBS), Query(queryPairs))
 import UnliftIO.MVar (MVar, newMVar, readMVar, modifyMVar_)
 
-import Control.Concurrent qualified as Concurrent
+import Control.Concurrent       qualified as Concurrent
 import Control.Concurrent.Async qualified as Async
-import Control.Concurrent.Chan qualified as Chan
-import Control.Exception.Safe qualified as Exception
-import Data.Aeson qualified as Aeson
-import Data.ByteString.Builder qualified as Builder
-import Data.ByteString.Char8 qualified as C8
-import Data.Fixed qualified as Fixed
-import Data.IntMap qualified as IntMap
-import Data.List qualified as List
-import Data.Time.Clock qualified as Time
-import Data.Time.LocalTime qualified as Time
-import URI.ByteString qualified as URI
+import Control.Concurrent.Chan  qualified as Chan
+import Control.Exception.Safe   qualified as Exception
+import Data.Aeson               qualified as Aeson
+import Data.ByteString.Builder  qualified as Builder
+import Data.ByteString.Char8    qualified as C8
+import Data.Fixed               qualified as Fixed
+import Data.IntMap              qualified as IntMap
+import Data.List                qualified as List
+import Data.Time.Clock          qualified as Time
+import Data.Time.LocalTime      qualified as Time
+import URI.ByteString           qualified as URI
 
 import NixFFI ( CppException(..), PathInfo(..)
               , getStoreDir, fingerprintPath, signString )

--- a/src/Nix.hs
+++ b/src/Nix.hs
@@ -77,7 +77,7 @@ priorityGroups = IntMap.elems . stores
 storeList :: Stores -> [Store]
 storeList = concat . priorityGroups
 
--- Tracking for exponential Timeout
+-- Tracking for timeout
 data StoreState = StoreState
   { enabled   :: Enabled
   , failures  :: Int

--- a/src/Nix.hs
+++ b/src/Nix.hs
@@ -4,7 +4,6 @@ module Nix (
   priorityGroups,
   storeList,
   -- raw reexports from NixFFI
-  CppException(..),
   PathInfo(..),
   getStoreDir,
   fingerprintPath,
@@ -175,15 +174,16 @@ queryPathInfoFromHashPart store hashPart = do
   pure $ join result
 
 dumpPath :: Store -> ByteString -> (Builder -> IO ()) -> IO ()
-dumpPath store hashPart builderCallback = do
-  result <- withTimeout store \url -> NixFFI.dumpPath url hashPart builderCallback
-  maybe (Exception.throwIO $ PathGoneException store hashPart) pure result
+dumpPath store storePath builderCallback = do
+  result <- withTimeout store \url -> NixFFI.dumpPath url storePath builderCallback
+  maybe (Exception.throwIO $ StreamingException store storePath) pure result
 
-data PathGoneException = PathGoneException Store ByteString
-instance Exception PathGoneException
-instance Show PathGoneException where
-  show (PathGoneException store hashPart) = C8.unpack $
-    "Info for " <> hashPart <> " found in " <> store.storeURL <> " but path is gone"
+data StreamingException = StreamingException Store ByteString
+  deriving anyclass Exception
+
+instance Show StreamingException where
+  show (StreamingException store storePath) = C8.unpack $
+    "Exception occurred while streaming " <> storePath <> " from " <> store.storeURL
 
 
 dumpLog :: Store -> ByteString -> IO (Maybe ByteString)

--- a/src/Nix.hs
+++ b/src/Nix.hs
@@ -1,0 +1,293 @@
+module Nix (
+  Stores,
+  Store,
+  priorityGroups,
+  storeList,
+  -- raw reexports from NixFFI
+  CppException(..),
+  PathInfo(..),
+  getStoreDir,
+  fingerprintPath,
+  signString,
+  -- wrapped reexports from NixFFI
+  initStores,
+  queryPathInfoFromHashPart,
+  dumpPath,
+  dumpLog,
+  -- Logging to stdout
+  Color(..),
+  colored,
+  logMsg,
+) where
+
+import Control.Applicative (empty)
+import Control.Exception.Safe (Exception)
+import Control.Monad (guard, join, when)
+import Control.Monad.IO.Class (liftIO)
+import Control.Monad.Trans.Maybe (MaybeT(..))
+import Data.ByteString (ByteString)
+import Data.ByteString.Builder (Builder)
+import Data.Either (partitionEithers)
+import Data.Foldable (for_)
+import Data.Function ((&))
+import Data.Functor ((<&>))
+import Data.IntMap (IntMap)
+import Data.Maybe (fromMaybe)
+import Data.Text (Text)
+import Data.Time.Clock (UTCTime)
+import System.IO (stdout)
+import URI.ByteString (URIRef(..), Scheme(schemeBS), Query(queryPairs))
+import UnliftIO.MVar (MVar, newMVar, readMVar, modifyMVar_)
+
+import Control.Concurrent qualified as Concurrent
+import Control.Concurrent.Async qualified as Async
+import Control.Concurrent.Chan qualified as Chan
+import Control.Exception.Safe qualified as Exception
+import Data.Aeson qualified as Aeson
+import Data.ByteString.Builder qualified as Builder
+import Data.ByteString.Char8 qualified as C8
+import Data.Fixed qualified as Fixed
+import Data.IntMap qualified as IntMap
+import Data.List qualified as List
+import Data.Time.Clock qualified as Time
+import Data.Time.Format.ISO8601 qualified as Time
+import Data.Time.LocalTime qualified as Time
+import URI.ByteString qualified as URI
+
+import NixFFI ( CppException(..), PathInfo(..)
+              , getStoreDir, fingerprintPath, signString )
+import Options (LogFormat(..))
+
+import NixFFI qualified
+
+type URI = URIRef URI.Absolute
+
+-- `Store`s are keyed by priority
+newtype Stores = Stores { stores :: IntMap [Store] }
+
+data Store = Store
+  { storeURL  :: ByteString
+  , parsedURI :: URI
+  , timeout   :: Word
+  , logFormat :: LogFormat
+  , storeVar  :: MVar StoreState
+  }
+
+priorityGroups :: Stores -> [[Store]]
+priorityGroups = IntMap.elems . stores
+
+storeList :: Stores -> [Store]
+storeList = concat . priorityGroups
+
+-- Tracking for exponential Timeout
+data StoreState = StoreState
+  { enabled   :: Enabled
+  , failures  :: Int
+  }
+
+-- `Store` uniqueness by only scheme/path is enforced in `initStores`
+instance Eq Store where
+  l == r = (l.parsedURI.uriScheme, l.parsedURI.uriPath) == (r.parsedURI.uriScheme, r.parsedURI.uriPath)
+
+instance Ord Store where
+  compare l r = compare (l.parsedURI.uriScheme, l.parsedURI.uriPath) (r.parsedURI.uriScheme, r.parsedURI.uriPath)
+
+data Enabled
+  = PreInit
+  | Enabled
+  | Disabled { disabledUntil :: UTCTime }
+  deriving stock Eq
+
+data BadStoreURLs = BadStoreURLs [ByteString]
+  deriving anyclass (Exception)
+  deriving stock (Show)
+
+data DuplicateStores = DuplicateStores [[ByteString]]
+  deriving anyclass (Exception)
+  deriving stock (Show)
+
+-- Some store types may be slow to initialize, so we do it async
+-- to allow queries against stores as soon as they come up.
+initStores :: Maybe Word -> Maybe Int -> LogFormat -> [ByteString] -> IO Stores
+initStores retryTimeout cores logFormat storeURLs = do
+  let (bad, good) = partitionEithers $ map parseStoreURL storeURLs
+
+  when (bad /= []) do Exception.throwIO $ BadStoreURLs bad
+
+  let dups = filter ((> 1) . List.length) $ List.groupBy (\a b -> snd a == snd b) good
+  when (dups /= []) do Exception.throwIO $ DuplicateStores (map (map fst) dups)
+
+  timeout <- maybe NixFFI.getMaxConnectTimeout pure retryTimeout
+
+  storesFlat <- mapM (uncurry $ preinitStore timeout logFormat) good
+
+  let byPrio = IntMap.fromListWith (++) $ flip map storesFlat \store ->
+        let prio = List.lookup "priority" store.parsedURI.uriQuery.queryPairs
+                 >>= fmap fst . C8.readInt
+        in  (fromMaybe 0 prio, [store])
+
+  let width = List.maximum $ map List.length $ IntMap.elems byPrio
+  maxCaps <- Concurrent.getNumCapabilities
+  Concurrent.setNumCapabilities (max 1 . min maxCaps $ fromMaybe width cores)
+
+  -- On the c++ side `openStore` is not thread safe and can be very slow
+  -- for remote stores that are currently unreachable, so we want to
+  -- initialize the local stores first.
+  let localsFirst = uncurry (++) $ List.partition isLocalStoreType storesFlat
+  retrying timeout initStore localsFirst
+
+  pure $ Stores byPrio
+
+retrying :: Word -> (a -> IO Bool) -> [a] -> IO ()
+retrying timeout act xs = do
+  chan <- Chan.newChan
+
+  let retry x = do
+        delaySecs timeout
+        Chan.writeChan chan x
+
+  let loop 0 = pure ()
+      loop n = do
+        x <- Chan.readChan chan
+        success <- act x
+        if success
+        then loop (n-1)
+        else retry x >> loop n
+
+  Async.link =<< Async.async (loop $ List.length xs)
+  for_ xs $ Chan.writeChan chan
+
+initStore :: Store -> IO Bool
+initStore store = do
+  enabled <- NixFFI.initStore store.storeURL
+
+  if enabled
+  then resetStore   PreInit store
+  else disableStore PreInit store
+
+  pure enabled
+
+queryPathInfoFromHashPart :: Store -> ByteString -> IO (Maybe (ByteString, PathInfo))
+queryPathInfoFromHashPart store hashPart = do
+  result <- withTimeout store \url -> runMaybeT do
+    storePath <- MaybeT $ NixFFI.queryPathFromHashPart url hashPart
+    pathInfo <- liftIO $ NixFFI.queryPathInfo url storePath
+    pure (storePath, pathInfo)
+  pure $ join result
+
+dumpPath :: Store -> ByteString -> (Builder -> IO ()) -> IO ()
+dumpPath store hashPath builderCallback = do
+  result <- withTimeout store \url -> NixFFI.dumpPath url hashPath builderCallback
+  maybe (Exception.throwIO CppException) pure result
+
+dumpLog :: Store -> ByteString -> IO (Maybe ByteString)
+dumpLog store baseName = do
+  result <- withTimeout store \url -> NixFFI.dumpLog url baseName
+  maybe (Exception.throwIO CppException) pure result
+
+parseStoreURL :: ByteString -> Either ByteString (ByteString, URI)
+parseStoreURL url = either Left check parsed
+  where
+    parsed = parseURI url <> parseURI ("local:" <> url)
+           & either (const $ Left url) Right
+    parseURI = URI.parseURI URI.laxURIParserOptions
+
+    check uri | isNormal || isSpecial || isPath = Right (url, uri)
+              | otherwise = Left url
+      where
+        isNormal  = uri.uriScheme.schemeBS /= "local"
+        isSpecial = uri.uriPath `elem` ["", "daemon", "local"]
+        isPath    = C8.take 1 (C8.dropWhile (== '.') uri.uriPath) == "/"
+
+isLocalStoreType :: Store -> Bool
+isLocalStoreType store = store.parsedURI.uriScheme.schemeBS `elem` ["dummy","file","local","local-overlay","unix"]
+
+preinitStore :: Word -> LogFormat -> ByteString -> URI -> IO Store
+preinitStore timeout logFormat storeURL parsedURI = do
+  storeVar <- newMVar StoreState { enabled = PreInit, failures = 0 }
+  pure Store{storeURL, parsedURI, timeout, logFormat, storeVar}
+
+
+-- Run a store operation if the store is enabled.
+--
+-- If the operation threw an exception on the C++ side,
+-- the store disabled for `timeout` seconds and Nothing is returned.
+--
+-- Operations may be slow and we want to allow concurrent actions on a store,
+-- so there is a possible race, but that's okay.
+withTimeout :: Store -> (ByteString -> IO a) -> IO (Maybe a)
+withTimeout store@Store{storeURL, storeVar} act = runMaybeT do
+  StoreState{enabled} <- readMVar storeVar
+  guard $ enabled == Enabled
+  Exception.try (liftIO $ act storeURL) >>= \case
+    Left CppException -> liftIO (disableStore Enabled store) >> empty
+    Right value       -> liftIO (resetStore   Enabled store) >> pure value
+
+-- Disable a store and fork a thread to reenable it after a delay
+disableStore :: Enabled -> Store -> IO ()
+disableStore restore store = modifyMVar_ store.storeVar \st@StoreState{enabled, failures} -> case enabled of
+  Disabled{} -> pure st
+  _ | otherwise -> do
+        _ <- Async.link =<< Async.async do
+          delaySecs store.timeout
+          reenableStore restore store
+
+        disabledSince <- Time.getCurrentTime
+        let disabledUntil = Time.addUTCTime (fromIntegral store.timeout) disabledSince
+        zonedUntil <- Time.utcToLocalZonedTime disabledUntil
+
+        logMsg Red store "Disabled" [("until", Aeson.toJSON zonedUntil), ("failures", Aeson.toJSON failures)]
+
+        pure st{enabled = Disabled{disabledUntil}}
+
+-- Allow operations to try using the store again. Increases the failure count.
+reenableStore :: Enabled -> Store -> IO ()
+reenableStore restore store = modifyMVar_ store.storeVar \st@StoreState{enabled, failures} -> case enabled of
+  Disabled{} -> do
+    when (restore == Enabled) do
+      logMsg Green store "Enabled" [("failures", Aeson.toJSON failures)]
+    pure st{enabled = restore, failures = failures + 1}
+  _          -> pure st
+
+-- After an operation succeeds, reset the failure count.
+-- This also signals when a store has successfully initialized.
+resetStore :: Enabled -> Store -> IO ()
+resetStore prior store = modifyMVar_ store.storeVar \st@StoreState{enabled} -> case enabled of
+  Disabled{} -> pure st
+  _          -> do
+    when (prior == PreInit) do
+      logMsg Green store "Enabled" []
+    pure st{enabled = Enabled, failures = 0}
+
+delaySecs :: Real a => a -> IO ()
+delaySecs = Concurrent.threadDelay . fromInteger
+          . \case Fixed.MkFixed n -> n
+          . fromRational @Fixed.Micro . toRational
+
+data Color = Red | Yellow | Green | Blue
+
+logMsg :: Color -> Store -> Builder -> [(Text, Aeson.Value)] -> IO ()
+logMsg color store event val = do
+  zoned <- Time.getZonedTime <&> Builder.stringUtf8 . Time.iso8601Show
+  let msg hi = zoned <> " " <> hi event <> " " <> url <> json
+
+  case store.logFormat of
+    Verbose        -> putLn $ msg (colored color)
+    VerboseNoColor -> putLn $ msg id
+    _              -> pure ()
+  where
+    putLn str = Builder.hPutBuilder stdout $ str <> "\n"
+    url  = Builder.byteString store.storeURL
+    json | val == [] = ""
+         | otherwise = " " <> (Aeson.fromEncoding . Aeson.toEncoding) val
+
+
+colored :: Color -> Builder -> Builder
+colored color str = "\o33[" <> ansiCode color <> "m" <> str <> "\o33[0m"
+
+ansiCode :: Color -> Builder
+ansiCode = \case
+  Red    -> ";31"
+  Yellow -> ";33"
+  Green  -> ";32"
+  Blue   -> ";34"

--- a/src/Nix.hs
+++ b/src/Nix.hs
@@ -15,6 +15,7 @@ module Nix (
   dumpPath,
   dumpLog,
   -- Logging to stdout
+  LogLevel(..),
   Color(..),
   colored,
   logMsg,
@@ -30,7 +31,6 @@ import Data.ByteString.Builder (Builder)
 import Data.Either (partitionEithers)
 import Data.Foldable (for_)
 import Data.Function ((&))
-import Data.Functor ((<&>))
 import Data.IntMap (IntMap)
 import Data.Maybe (fromMaybe)
 import Data.Text (Text)
@@ -50,7 +50,6 @@ import Data.Fixed qualified as Fixed
 import Data.IntMap qualified as IntMap
 import Data.List qualified as List
 import Data.Time.Clock qualified as Time
-import Data.Time.Format.ISO8601 qualified as Time
 import Data.Time.LocalTime qualified as Time
 import URI.ByteString qualified as URI
 
@@ -176,9 +175,16 @@ queryPathInfoFromHashPart store hashPart = do
   pure $ join result
 
 dumpPath :: Store -> ByteString -> (Builder -> IO ()) -> IO ()
-dumpPath store hashPath builderCallback = do
-  result <- withTimeout store \url -> NixFFI.dumpPath url hashPath builderCallback
-  maybe (Exception.throwIO CppException) pure result
+dumpPath store hashPart builderCallback = do
+  result <- withTimeout store \url -> NixFFI.dumpPath url hashPart builderCallback
+  maybe (Exception.throwIO $ PathGoneException store hashPart) pure result
+
+data PathGoneException = PathGoneException Store ByteString
+instance Exception PathGoneException
+instance Show PathGoneException where
+  show (PathGoneException store hashPart) = C8.unpack $
+    "Info for " <> hashPart <> " found in " <> store.storeURL <> " but path is gone"
+
 
 dumpLog :: Store -> ByteString -> IO (Maybe ByteString)
 dumpLog store baseName = do
@@ -236,7 +242,7 @@ disableStore restore store = modifyMVar_ store.storeVar \st@StoreState{enabled, 
         let disabledUntil = Time.addUTCTime (fromIntegral store.timeout) disabledSince
         zonedUntil <- Time.utcToLocalZonedTime disabledUntil
 
-        logMsg Red store "Disabled" [("until", Aeson.toJSON zonedUntil), ("failures", Aeson.toJSON failures)]
+        logMsg Info Red store "Disabled" [("until", Aeson.toJSON zonedUntil), ("failures", Aeson.toJSON failures)]
 
         pure st{enabled = Disabled{disabledUntil}}
 
@@ -245,7 +251,7 @@ reenableStore :: Enabled -> Store -> IO ()
 reenableStore restore store = modifyMVar_ store.storeVar \st@StoreState{enabled, failures} -> case enabled of
   Disabled{} -> do
     when (restore == Enabled) do
-      logMsg Green store "Enabled" [("failures", Aeson.toJSON failures)]
+      logMsg Info Green store "Enabled" [("failures", Aeson.toJSON failures)]
     pure st{enabled = restore, failures = failures + 1}
   _          -> pure st
 
@@ -256,7 +262,7 @@ resetStore prior store = modifyMVar_ store.storeVar \st@StoreState{enabled} -> c
   Disabled{} -> pure st
   _          -> do
     when (prior == PreInit) do
-      logMsg Green store "Enabled" []
+      logMsg Info Green store "Enabled" []
     pure st{enabled = Enabled, failures = 0}
 
 delaySecs :: Real a => a -> IO ()
@@ -264,19 +270,25 @@ delaySecs = Concurrent.threadDelay . fromInteger
           . \case Fixed.MkFixed n -> n
           . fromRational @Fixed.Micro . toRational
 
+data LogLevel =  Info | Debug
+
 data Color = Red | Yellow | Green | Blue
 
-logMsg :: Color -> Store -> Builder -> [(Text, Aeson.Value)] -> IO ()
-logMsg color store event val = do
-  zoned <- Time.getZonedTime <&> Builder.stringUtf8 . Time.iso8601Show
-  let msg hi = zoned <> " " <> hi event <> " " <> url <> json
-
-  case store.logFormat of
-    Verbose        -> putLn $ msg (colored color)
-    VerboseNoColor -> putLn $ msg id
-    _              -> pure ()
+logMsg :: LogLevel -> Color -> Store -> Builder -> [(Text, Aeson.Value)] -> IO ()
+logMsg level color store event val = when shouldLog do
+  Builder.hPutBuilder stdout $ highlight event <> " " <> url <> json <> "\n"
   where
-    putLn str = Builder.hPutBuilder stdout $ str <> "\n"
+    shouldLog = case (level, store.logFormat) of
+      (_    , Quiet         ) -> False
+      (Info , _             ) -> True
+      (Debug, Verbose       ) -> True
+      (Debug, VerboseNoColor) -> True
+      _                       -> False
+
+    highlight = case store.logFormat of
+      Verbose -> colored color
+      _       -> id
+
     url  = Builder.byteString store.storeURL
     json | val == [] = ""
          | otherwise = " " <> (Aeson.fromEncoding . Aeson.toEncoding) val

--- a/src/Nix.hs
+++ b/src/Nix.hs
@@ -183,7 +183,7 @@ dumpPath store hashPath builderCallback = do
 dumpLog :: Store -> ByteString -> IO (Maybe ByteString)
 dumpLog store baseName = do
   result <- withTimeout store \url -> NixFFI.dumpLog url baseName
-  maybe (Exception.throwIO CppException) pure result
+  pure $ join result
 
 parseStoreURL :: ByteString -> Either ByteString (ByteString, URI)
 parseStoreURL url = either Left check parsed

--- a/src/Nix.hs
+++ b/src/Nix.hs
@@ -18,6 +18,8 @@ module Nix (
   Color(..),
   colored,
   logMsg,
+  -- Convenience reexport from Aeson
+  (.=)
 ) where
 
 import Control.Applicative (empty)
@@ -25,6 +27,7 @@ import Control.Exception.Safe (Exception)
 import Control.Monad (guard, join, when)
 import Control.Monad.IO.Class (liftIO)
 import Control.Monad.Trans.Maybe (MaybeT(..))
+import Data.Aeson ((.=))
 import Data.ByteString (ByteString)
 import Data.ByteString.Builder (Builder)
 import Data.Either (partitionEithers)
@@ -32,7 +35,6 @@ import Data.Foldable (for_)
 import Data.Function ((&))
 import Data.IntMap (IntMap)
 import Data.Maybe (fromMaybe)
-import Data.Text (Text)
 import Data.Time.Clock (UTCTime)
 import System.IO (stdout)
 import URI.ByteString (URIRef(..), Scheme(schemeBS), Query(queryPairs))
@@ -242,7 +244,7 @@ disableStore restore store = modifyMVar_ store.storeVar \st@StoreState{enabled, 
         let disabledUntil = Time.addUTCTime (fromIntegral store.timeout) disabledSince
         zonedUntil <- Time.utcToLocalZonedTime disabledUntil
 
-        logMsg Info Red store "Disabled" [("until", Aeson.toJSON zonedUntil), ("failures", Aeson.toJSON failures)]
+        logMsg Info Red store "Disabled" ("until" .= zonedUntil <> "failures" .= failures)
 
         pure st{enabled = Disabled{disabledUntil}}
 
@@ -251,7 +253,7 @@ reenableStore :: Enabled -> Store -> IO ()
 reenableStore restore store = modifyMVar_ store.storeVar \st@StoreState{enabled, failures} -> case enabled of
   Disabled{} -> do
     when (restore == Enabled) do
-      logMsg Info Green store "Enabled" [("failures", Aeson.toJSON failures)]
+      logMsg Info Green store "Enabled" ("failures" .= failures)
     pure st{enabled = restore, failures = failures + 1}
   _          -> pure st
 
@@ -262,7 +264,7 @@ resetStore prior store = modifyMVar_ store.storeVar \st@StoreState{enabled} -> c
   Disabled{} -> pure st
   _          -> do
     when (prior == PreInit) do
-      logMsg Info Green store "Enabled" []
+      logMsg Info Green store "Enabled" mempty
     pure st{enabled = Enabled, failures = 0}
 
 delaySecs :: Real a => a -> IO ()
@@ -274,9 +276,9 @@ data LogLevel =  Info | Debug
 
 data Color = Red | Yellow | Green | Blue
 
-logMsg :: LogLevel -> Color -> Store -> Builder -> [(Text, Aeson.Value)] -> IO ()
-logMsg level color store event val = when shouldLog do
-  Builder.hPutBuilder stdout $ highlight event <> " " <> url <> json <> "\n"
+logMsg :: LogLevel -> Color -> Store -> Builder -> Aeson.Series -> IO ()
+logMsg level color store event series = when shouldLog do
+  Builder.hPutBuilder stdout $ highlight event <> " " <> url <> " " <> json <> "\n"
   where
     shouldLog = case (level, store.logFormat) of
       (_    , Quiet         ) -> False
@@ -289,10 +291,10 @@ logMsg level color store event val = when shouldLog do
       Verbose -> colored color
       _       -> id
 
-    url  = Builder.byteString store.storeURL
-    json | val == [] = ""
-         | otherwise = " " <> (Aeson.fromEncoding . Aeson.toEncoding) val
+    url | store.parsedURI.uriPath == "" = "daemon"
+        | otherwise = Builder.byteString store.storeURL
 
+    json = Aeson.fromEncoding $ Aeson.pairs series
 
 colored :: Color -> Builder -> Builder
 colored color str = "\o33[" <> ansiCode color <> "m" <> str <> "\o33[0m"

--- a/src/NixFFI.hsc
+++ b/src/NixFFI.hsc
@@ -13,7 +13,6 @@ import Foreign (FunPtr, Ptr, Storable(..))
 import Foreign.C (CChar, CInt(..), CLong, CSize(..), CString, CULong(..))
 
 import qualified Control.Exception.Safe  as Exception
-import qualified Control.Monad           as Monad
 import qualified Control.Monad.Managed   as Managed
 import qualified Data.ByteString         as ByteString
 import qualified Data.ByteString.Base16  as Base16
@@ -29,6 +28,11 @@ import qualified Foreign
 data CppException = CppException
   deriving anyclass (Exception)
   deriving stock (Show)
+
+checkSuccess :: CInt -> IO ()
+checkSuccess ec = case ec of
+    #{const RETURN_OK}   -> pure ()
+    _ -> Exception.throwIO CppException
 
 checkExitCode :: CInt -> IO Bool
 checkExitCode ec = case ec of
@@ -217,7 +221,7 @@ queryPathFromHashPart url hashPart =
   ByteString.useAsCString url \cUrl ->
   ByteString.useAsCString hashPart \cHashPart -> do
     Foreign.alloca \output -> do
-        let open = queryPathFromHashPart_ cUrl cHashPart output >>= checkExitCode
+        let open = queryPathFromHashPart_ cUrl cHashPart output >>= checkSuccess
         let close = freeString output
         Exception.bracket_ open close do
             string_@String_{ data_} <- peek output
@@ -233,7 +237,7 @@ queryPathInfo url storePath =
     ByteString.useAsCString url \cUrl ->
     ByteString.useAsCString storePath \cStorePath -> do
         Foreign.alloca \output -> do
-            let open = queryPathInfo_ cUrl cStorePath output >>= checkExitCode
+            let open = queryPathInfo_ cUrl cStorePath output >>= checkSuccess
             let close = freePathInfo output
             Exception.bracket_ open close do
                 cPathInfo <- peek output
@@ -279,7 +283,7 @@ signString secretKey fingerprint =
     ByteString.useAsCString secretKey \cSecretKey ->
         ByteString.useAsCString fingerprint \cFingerprint ->
             Foreign.alloca \output -> do
-                let open = signString_ cSecretKey cFingerprint output >>= checkExitCode
+                let open = signString_ cSecretKey cFingerprint output >>= checkSuccess
                 let close = freeString output
                 Exception.bracket_ open close do
                     string_ <- peek output
@@ -289,7 +293,7 @@ foreign import ccall "dumpPath" dumpPath_
     :: CString -> CString -> FunPtr (Ptr CChar -> CSize -> IO Bool) -> IO CInt
 
 dumpPath :: ByteString -> ByteString -> (Builder -> IO ()) -> IO ()
-dumpPath url hashPart builderCallback = do
+dumpPath url storePath builderCallback = do
     result <- IORef.newIORef (Right ())
 
     let cCallback :: Ptr CChar -> CSize -> IO Bool
@@ -326,11 +330,8 @@ dumpPath url hashPart builderCallback = do
     wrappedCCallback <- wrapCallback cCallback
 
     ByteString.useAsCString url \cUrl ->
-        ByteString.useAsCString hashPart \cHashPart -> do
-            success <- dumpPath_ cUrl cHashPart wrappedCCallback >>= checkExitCode
-
-            Monad.when (not success) do
-                IORef.writeIORef result (Left (Exception.toException NoSuchPath))
+        ByteString.useAsCString storePath \cStorePath -> do
+            dumpPath_ cUrl cStorePath wrappedCCallback >>= checkSuccess
 
     Foreign.freeHaskellFunPtr wrappedCCallback
 
@@ -344,7 +345,7 @@ dumpLog url baseName =
     ByteString.useAsCString url \cUrl ->
     ByteString.useAsCString baseName \cBaseName -> do
         Foreign.alloca \output -> do
-            let open = dumpLog_ cUrl cBaseName output >>= checkExitCode
+            let open = dumpLog_ cUrl cBaseName output >>= checkSuccess
             let close = freeString output
             Exception.bracket_ open close do
                 string_@String_{ data_} <- peek output

--- a/src/NixFFI.hsc
+++ b/src/NixFFI.hsc
@@ -1,14 +1,6 @@
-{-# LANGUAGE BlockArguments           #-}
-{-# LANGUAGE DeriveAnyClass           #-}
-{-# LANGUAGE DerivingStrategies       #-}
-{-# LANGUAGE DuplicateRecordFields    #-}
 {-# LANGUAGE ForeignFunctionInterface #-}
-{-# LANGUAGE MultiWayIf               #-}
-{-# LANGUAGE NamedFieldPuns           #-}
-{-# LANGUAGE OverloadedStrings        #-}
-{-# LANGUAGE TypeApplications         #-}
 
-module Nix where
+module NixFFI where
 
 import Control.Applicative (empty)
 import Control.Exception (Exception, SomeException)
@@ -18,9 +10,9 @@ import Data.ByteString.Builder (Builder)
 import Data.Vector (Vector)
 import Data.Word (Word64)
 import Foreign (FunPtr, Ptr, Storable(..))
-import Foreign.C (CChar, CLong, CSize(..), CString)
+import Foreign.C (CChar, CInt(..), CLong, CSize(..), CString, CULong(..))
 
-import qualified Control.Exception       as Exception
+import qualified Control.Exception.Safe  as Exception
 import qualified Control.Monad           as Monad
 import qualified Control.Monad.Managed   as Managed
 import qualified Data.ByteString         as ByteString
@@ -34,13 +26,20 @@ import qualified Foreign
 
 #include "nix.hh"
 
-foreign import ccall "initStore" initStore :: IO ()
+data CppException = CppException
+  deriving anyclass (Exception)
+  deriving stock (Show)
 
-foreign import ccall "initStoreUri" initStoreUri_ :: CString -> IO ()
+checkExitCode :: CInt -> IO Bool
+checkExitCode ec = case ec of
+    #{const RETURN_OK}   -> pure True
+    #{const RETURN_FAIL} -> pure False
+    _ -> Exception.throwIO CppException
 
-initStoreUri :: ByteString -> IO ()
-initStoreUri uri = do
-    ByteString.useAsCString uri initStoreUri_
+foreign import ccall "initStore" initStore_ :: CString -> IO CInt
+
+initStore :: ByteString -> IO Bool
+initStore url = ByteString.useAsCString url initStore_ >>= checkExitCode
 
 foreign import ccall "freeString" freeString :: Ptr String_ -> IO ()
 
@@ -201,33 +200,40 @@ getStoreDir =
             string_ <- peek output
             fromString_ string_
 
+foreign import ccall "getMaxConnectTimeout" getMaxConnectTimeout_ :: IO CULong
+
+getMaxConnectTimeout :: IO Word
+getMaxConnectTimeout = fromIntegral <$> getMaxConnectTimeout_
+
 data NoSuchPath = NoSuchPath
     deriving anyclass (Exception)
     deriving stock (Show)
 
 foreign import ccall "queryPathFromHashPart" queryPathFromHashPart_
-    :: CString -> Ptr String_ -> IO ()
+    :: CString -> CString -> Ptr String_ -> IO CInt
 
-queryPathFromHashPart :: ByteString -> IO (Either NoSuchPath ByteString)
-queryPathFromHashPart hashPart = do
-    ByteString.useAsCString hashPart \cHashPart -> do
-        Foreign.alloca \output -> do
-            let open = queryPathFromHashPart_ cHashPart output
-            let close = freeString output
-            Exception.bracket_ open close do
-                string_@String_{ data_} <- peek output
-                if data_ == Foreign.nullPtr
-                    then return (Left NoSuchPath)
-                    else fmap Right (fromString_ string_)
+queryPathFromHashPart :: ByteString -> ByteString -> IO (Maybe ByteString)
+queryPathFromHashPart url hashPart =
+  ByteString.useAsCString url \cUrl ->
+  ByteString.useAsCString hashPart \cHashPart -> do
+    Foreign.alloca \output -> do
+        let open = queryPathFromHashPart_ cUrl cHashPart output >>= checkExitCode
+        let close = freeString output
+        Exception.bracket_ open close do
+            string_@String_{ data_} <- peek output
+            if data_ == Foreign.nullPtr
+                then pure Nothing
+                else fmap Just (fromString_ string_)
 
 foreign import ccall "queryPathInfo" queryPathInfo_
-    :: CString -> Ptr CPathInfo -> IO ()
+    :: CString -> CString -> Ptr CPathInfo -> IO CInt
 
-queryPathInfo :: ByteString -> IO PathInfo
-queryPathInfo storePath = do
+queryPathInfo :: ByteString -> ByteString -> IO PathInfo
+queryPathInfo url storePath =
+    ByteString.useAsCString url \cUrl ->
     ByteString.useAsCString storePath \cStorePath -> do
         Foreign.alloca \output -> do
-            let open = queryPathInfo_ cStorePath output
+            let open = queryPathInfo_ cUrl cStorePath output >>= checkExitCode
             let close = freePathInfo output
             Exception.bracket_ open close do
                 cPathInfo <- peek output
@@ -266,24 +272,24 @@ fingerprintPath storePath PathInfo{ narHash, narSize, references } = do
                 <>  foldMap (\r -> "," <> Builder.byteString r) rs
 
 foreign import ccall "signString" signString_
-    :: CString -> CString -> Ptr String_ -> IO ()
+    :: CString -> CString -> Ptr String_ -> IO CInt
 
 signString :: ByteString -> ByteString -> IO ByteString
 signString secretKey fingerprint =
     ByteString.useAsCString secretKey \cSecretKey ->
         ByteString.useAsCString fingerprint \cFingerprint ->
             Foreign.alloca \output -> do
-                let open = signString_ cSecretKey cFingerprint output
+                let open = signString_ cSecretKey cFingerprint output >>= checkExitCode
                 let close = freeString output
                 Exception.bracket_ open close do
                     string_ <- peek output
                     fromString_ string_
 
 foreign import ccall "dumpPath" dumpPath_
-    :: CString -> FunPtr (Ptr CChar -> CSize -> IO Bool) -> IO Bool
+    :: CString -> CString -> FunPtr (Ptr CChar -> CSize -> IO Bool) -> IO CInt
 
-dumpPath :: ByteString -> (Builder -> IO ()) -> IO (Either SomeException ())
-dumpPath hashPart builderCallback = do
+dumpPath :: ByteString -> ByteString -> (Builder -> IO ()) -> IO ()
+dumpPath url hashPart builderCallback = do
     result <- IORef.newIORef (Right ())
 
     let cCallback :: Ptr CChar -> CSize -> IO Bool
@@ -319,24 +325,26 @@ dumpPath hashPart builderCallback = do
 
     wrappedCCallback <- wrapCallback cCallback
 
-    ByteString.useAsCString hashPart \cHashPart -> do
-        success <- dumpPath_ cHashPart wrappedCCallback
+    ByteString.useAsCString url \cUrl ->
+        ByteString.useAsCString hashPart \cHashPart -> do
+            success <- dumpPath_ cUrl cHashPart wrappedCCallback >>= checkExitCode
 
-        Monad.when (not success) do
-            IORef.writeIORef result (Left (Exception.toException NoSuchPath))
+            Monad.when (not success) do
+                IORef.writeIORef result (Left (Exception.toException NoSuchPath))
 
     Foreign.freeHaskellFunPtr wrappedCCallback
 
-    IORef.readIORef result
+    IORef.readIORef result >>= either Exception.throwIO pure
 
 foreign import ccall "dumpLog" dumpLog_
-    :: CString -> Ptr String_ -> IO ()
+    :: CString -> CString -> Ptr String_ -> IO CInt
 
-dumpLog :: ByteString -> IO (Maybe ByteString)
-dumpLog baseName = do
+dumpLog :: ByteString -> ByteString -> IO (Maybe ByteString)
+dumpLog url baseName =
+    ByteString.useAsCString url \cUrl ->
     ByteString.useAsCString baseName \cBaseName -> do
         Foreign.alloca \output -> do
-            let open = dumpLog_ cBaseName output
+            let open = dumpLog_ cUrl cBaseName output >>= checkExitCode
             let close = freeString output
             Exception.bracket_ open close do
                 string_@String_{ data_} <- peek output

--- a/src/Options.hs
+++ b/src/Options.hs
@@ -63,10 +63,14 @@ parseSocket :: Parser Socket
 parseSocket = tcp <|> unix
     where
     tcp = do
+        let hostDoc = Options.nest 2 $ Options.vsep
+              [ "The hostname to bind to. Can be one of the special values:"
+              , "*|*4|!4|*6|!6|IPv4|IPv6" ]
+
         host <- Options.strOption
             (   Options.long "host"
-            <>  Options.help "The hostname to bind to"
-            <>  Options.metavar "*|*4|!4|*6|!6|IPv4|IPv6"
+            <>  Options.helpDoc (Just hostDoc)
+            <>  Options.metavar "HOST"
                 -- The default host for warp is "*4", but we specify a default of
                 -- "*" for backwards compatibility with nix-serve, which defaults to
                 -- binding to any IP address.  Also, binding to any IP address is
@@ -78,11 +82,13 @@ parseSocket = tcp <|> unix
 
         port <- Options.option Options.auto
             (   Options.long "port"
-            <>  Options.help "The port to bind to"
-            <>  Options.metavar "0-65535"
+            <>  Options.short 'p'
+            <>  Options.help "The port to bind to: 0-65535"
+            <>  Options.metavar "PORT"
                 -- This is also for backwards compatibility with nix-serve, which
                 -- defaults to port 5000.
             <>  Options.value 5000
+            <>  Options.showDefault
             )
 
         return TCP{..}
@@ -91,8 +97,9 @@ parseSocket = tcp <|> unix
       backlog <- Options.option Options.auto
           (   Options.long "backlog"
           <>  Options.help "The maximum number of connections allowed for the backlog"
-          <>  Options.metavar "INTEGER"
+          <>  Options.metavar "N"
           <>  Options.value 1024
+          <>  Options.showDefault
           )
 
       path <- Options.strOption
@@ -110,11 +117,16 @@ parseListen :: Parser Socket
 parseListen = Options.option (parseReader $ tcp <|> unix)
     (   Options.long "listen"
     <>  Options.short 'l'
-    <>  Options.help "The TLS-enabled host and port to bind to"
-    <>  Options.metavar "[HOST]:PORT|UNIX_SOCKET"
+    <>  Options.helpDoc (Just helpDoc)
+    <>  Options.metavar "ADDR"
     <>  Options.hidden
     )
     where
+    helpDoc = Options.vsep
+      [ "The TLS-enabled host and port to bind to in the format:"
+      , "  [HOST]:PORT|UNIX_SOCKET"
+      , "(provided to backwards compatibility)" ]
+
     tcp = do
         host <- parseHost <|> pure "*"
         _ <- ":"
@@ -177,7 +189,7 @@ parseTimeout =
     Options.option Options.auto
         (   Options.long "timeout"
         <>  Options.help "Timeout for requests"
-        <>  Options.metavar "SECONDS"
+        <>  Options.metavar "SECS"
             -- nix-serve does not timeout requests, but warp insists on a
             -- timeout, so we use the same default timeout as hydra
         <>  Options.value (10 * 60)
@@ -229,17 +241,18 @@ parseStores = fmap toNE . Options.many $ Options.strOption
     toNE = fromMaybe (NonEmpty.singleton "") . NonEmpty.nonEmpty
     helpDoc = Options.vsep
         [ "nix store uri. see: man nix3-help-stores"
-        , "Maybe be provided more than once. Respects the `priority` setting if given multiple stores."
+        , "Maybe be provided more than once."
+        , "Respects the `priority` setting if given multiple stores."
         ]
 
 parseRetryTimeout :: Parser (Maybe Word)
 parseRetryTimeout = optional $ Options.option Options.auto
     (   Options.long "retry-timeout"
     <>  Options.helpDoc (Just helpDoc)
-    <>  Options.metavar "SECONDS"
+    <>  Options.metavar "SECS"
     )
     where
-      helpDoc = Options.hsep
+      helpDoc = Options.vsep
         [ "Timeout before retying a remote after a connection fails."
         , "Default to nix.settings.connect-timeout"
         ]
@@ -251,9 +264,10 @@ parseCores = optional $ Options.option Options.auto
     <>  Options.metavar "N"
     )
     where
-      helpDoc = Options.hsep
+      helpDoc = Options.vsep
         [ "The number of cores to use"
-        , "Defaults to the largest number of --store args with the same priority."
+        , "Defaults to the largest number of"
+        , "--store args with the same priority."
         ]
 
 parseReader :: Parsec Void String a -> ReadM a

--- a/src/Options.hs
+++ b/src/Options.hs
@@ -1,13 +1,11 @@
-{-# LANGUAGE ApplicativeDo     #-}
-{-# LANGUAGE BlockArguments    #-}
-{-# LANGUAGE LambdaCase        #-}
-{-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE RecordWildCards   #-}
+{-# LANGUAGE RecordWildCards #-}
 
 module Options where
 
-import Control.Applicative (optional, (<|>))
+import Control.Applicative ((<|>), asum, optional)
 import Data.ByteString (ByteString)
+import Data.List.NonEmpty (NonEmpty)
+import Data.Maybe (fromMaybe)
 import Data.String (IsString(..))
 import Data.Void (Void)
 import Network.Wai.Handler.Warp (HostPreference, Port)
@@ -15,10 +13,22 @@ import Numeric.Natural (Natural)
 import Options.Applicative (Parser, ParserInfo, ReadM)
 import Text.Megaparsec (Parsec)
 
+import qualified Data.List.NonEmpty              as NonEmpty
 import qualified Options.Applicative             as Options
 import qualified Options.Applicative.Help.Pretty as Options
 import qualified Text.Megaparsec                 as Megaparsec
 import qualified Text.Megaparsec.Char.Lexer      as Lexer
+
+data Options = Options
+    { socket       :: Socket
+    , ssl          :: SSL
+    , priority     :: Integer
+    , timeout      :: Natural
+    , logFormat    :: LogFormat
+    , storeURLs    :: NonEmpty ByteString
+    , retryTimeout :: Maybe Word
+    , cores        :: Maybe Int
+    }
 
 data Socket
     = TCP { host :: HostPreference, port :: Port }
@@ -32,33 +42,112 @@ data LogFormat = Quiet
                | Verbose
                | VerboseNoColor
 
-data Options = Options
-    { priority  :: Integer
-    , socket    :: Socket
-    , ssl       :: SSL
-    , store     :: Maybe ByteString
-    , timeout   :: Natural
-    , logFormat :: LogFormat
-    }
+parserInfo :: ParserInfo Options
+parserInfo = Options.info
+    (Options.helper <*> parseOptions)
+    (Options.progDesc "Serve the current Nix store as a binary cache")
 
-parseCert :: Parser FilePath
-parseCert =
-    Options.strOption
-        (   Options.long "ssl-cert"
-        <>  Options.help "The path to the SSL certificate file"
-        <>  Options.metavar "FILE"
-        )
+parseOptions :: Parser Options
+parseOptions = do
+    socket <- parseSocket <|> parseListen
+    priority <- parsePriority
+    ssl <- parseSsl <|> pure Disabled
+    timeout <- parseTimeout
+    logFormat <- parseLogFormat
+    storeURLs <- parseStores
+    retryTimeout <- parseRetryTimeout
+    cores <- parseCores
+    return Options{..}
 
-parseKey :: Parser FilePath
-parseKey =
-    Options.strOption
-        (   Options.long "ssl-key"
-        <>  Options.help "The path to the SSL key file"
-        <>  Options.metavar "FILE"
-        )
+parseSocket :: Parser Socket
+parseSocket = tcp <|> unix
+    where
+    tcp = do
+        host <- Options.strOption
+            (   Options.long "host"
+            <>  Options.help "The hostname to bind to"
+            <>  Options.metavar "*|*4|!4|*6|!6|IPv4|IPv6"
+                -- The default host for warp is "*4", but we specify a default of
+                -- "*" for backwards compatibility with nix-serve, which defaults to
+                -- binding to any IP address.  Also, binding to any IP address is
+                -- probably a better default anyway than binding to only IPv4
+                -- addresses.
+            <>  Options.value "*"
+            <>  Options.showDefaultWith (\_ -> "*")
+            )
 
-parseSslEnabled :: Parser SSL
-parseSslEnabled = do
+        port <- Options.option Options.auto
+            (   Options.long "port"
+            <>  Options.help "The port to bind to"
+            <>  Options.metavar "0-65535"
+                -- This is also for backwards compatibility with nix-serve, which
+                -- defaults to port 5000.
+            <>  Options.value 5000
+            )
+
+        return TCP{..}
+
+    unix = do
+      backlog <- Options.option Options.auto
+          (   Options.long "backlog"
+          <>  Options.help "The maximum number of connections allowed for the backlog"
+          <>  Options.metavar "INTEGER"
+          <>  Options.value 1024
+          )
+
+      path <- Options.strOption
+          (   Options.long "socket"
+          <>  Options.short 'S'
+          <>  Options.help "The socket to bind to"
+          <>  Options.metavar "PATH"
+          )
+
+      return Unix{..}
+
+-- This is only for backwards compatibility with nix-serve, which supports
+-- the --listen option
+parseListen :: Parser Socket
+parseListen = Options.option (parseReader $ tcp <|> unix)
+    (   Options.long "listen"
+    <>  Options.short 'l'
+    <>  Options.help "The TLS-enabled host and port to bind to"
+    <>  Options.metavar "[HOST]:PORT|UNIX_SOCKET"
+    <>  Options.hidden
+    )
+    where
+    tcp = do
+        host <- parseHost <|> pure "*"
+        _ <- ":"
+        port <- Lexer.decimal
+        _ <- optional ":ssl" -- See: [NOTE: enable-ssl]
+        return TCP{..}
+
+    unix = do
+        path <- Megaparsec.takeRest
+        return Unix{path, backlog = 1024}
+
+    parseHost = do
+        let ipv6 = Megaparsec.try do
+              proto <- Megaparsec.takeWhileP Nothing (/= '[') <* "["
+              addr <- Megaparsec.takeWhileP Nothing (/= ']') <* "]"
+              _ <- Megaparsec.lookAhead ":"
+              pure . fromString $ proto <> "[" <> addr <> "]"
+
+        let other = Megaparsec.takeWhileP Nothing (/= ':')
+
+        fmap fromString $ ipv6 <|> other
+
+
+parsePriority :: Parser Integer
+parsePriority = Options.option Options.auto
+    (   Options.long "priority"
+    <>  Options.help "The priority of the cache (lower is higher priority)"
+    <>  Options.metavar "INTEGER"
+    <>  Options.value 30
+    )
+
+parseSsl :: Parser SSL
+parseSsl = do
     -- [NOTE: enable-ssl]
     --
     -- We parse this for backwards compatibility with nix-serve, but ignore
@@ -69,80 +158,19 @@ parseSslEnabled = do
         <>  Options.internal
         )
 
-    cert <- parseCert
+    cert <- Options.strOption
+        (   Options.long "ssl-cert"
+        <>  Options.help "The path to the SSL certificate file"
+        <>  Options.metavar "FILE"
+        )
 
-    key <- parseKey
+    key <- Options.strOption
+        (   Options.long "ssl-key"
+        <>  Options.help "The path to the SSL key file"
+        <>  Options.metavar "FILE"
+        )
 
     return Enabled{..}
-
-parseSsl :: Parser SSL
-parseSsl = parseSslEnabled <|> pure Disabled
-
-parseStore :: Parser (Maybe ByteString)
-parseStore = optional $ Options.strOption
-  (   Options.long "store"
-  <>  Options.help "nix store uri. see: man nix3-help-stores"
-  <>  Options.metavar "STORE"
-  )
-
-parseTcp :: Parser Socket
-parseTcp = do
-    host <- Options.strOption
-        (   Options.long "host"
-        <>  Options.help "The hostname to bind to"
-        <>  Options.metavar "*|*4|!4|*6|!6|IPv4|IPv6"
-            -- The default host for warp is "*4", but we specify a default of
-            -- "*" for backwards compatibility with nix-serve, which defaults to
-            -- binding to any IP address.  Also, binding to any IP address is
-            -- probably a better default anyway than binding to only IPv4
-            -- addresses.
-        <>  Options.value "*"
-        <>  Options.showDefaultWith (\_ -> "*")
-        )
-
-    port <- Options.option Options.auto
-        (   Options.long "port"
-        <>  Options.help "The port to bind to"
-        <>  Options.metavar "0-65535"
-            -- This is also for backwards compatibility with nix-serve, which
-            -- defaults to port 5000.
-        <>  Options.value 5000
-        )
-
-    return TCP{..}
-
-defaultBacklog :: Natural
-defaultBacklog = 1024
-
-parseUnix :: Parser Socket
-parseUnix = do
-    backlog <- Options.option Options.auto
-        (   Options.long "backlog"
-        <>  Options.help "The maximum number of connections allowed for the backlog"
-        <>  Options.metavar "INTEGER"
-        <>  Options.value defaultBacklog
-        )
-
-    path <- Options.strOption
-        (   Options.long "socket"
-        <>  Options.short 'S'
-        <>  Options.help "The socket to bind to"
-        <>  Options.metavar "PATH"
-        )
-
-    return Unix{..}
-
-parseSocket :: Parser Socket
-parseSocket = parseTcp <|> parseUnix
-
-parsePriority :: Parser Integer
-parsePriority =
-    Options.option Options.auto
-        (   Options.long "priority"
-        <>  Options.help "The priority of the cache (lower is higher priority)"
-        <>  Options.metavar "INTEGER"
-        <>  Options.value 30
-        )
 
 parseTimeout :: Parser Natural
 parseTimeout =
@@ -156,22 +184,31 @@ parseTimeout =
         )
 
 parseLogFormat :: Parser LogFormat
-parseLogFormat =
-        Options.flag' Quiet
-            (   Options.long "quiet"
-            <>  Options.help "Disable logging. Alias for --log-format quiet"
-            )
-    <|> Options.flag' Verbose
-            (   Options.long "verbose"
-            <>  Options.help "Verbose logging. Alias for --log-format verbose"
-            )
-    <|> Options.option readLogFormat
-            (   Options.long "log-format"
-            <>  Options.metavar "FORMAT"
-            <>  Options.helpDoc (Just helpDoc)
-            <>  Options.value Apache
-            )
+parseLogFormat = asum [quiet, verbose, other]
   where
+    quiet = Options.flag' Quiet
+        (   Options.long "quiet"
+        <>  Options.help "Disable logging. Alias for --log-format quiet"
+        )
+    verbose = Options.flag' Verbose
+        (   Options.long "verbose"
+        <>  Options.help "Verbose logging. Alias for --log-format verbose"
+        )
+    other = Options.option readLogFormat
+        (   Options.long "log-format"
+        <>  Options.metavar "FORMAT"
+        <>  Options.helpDoc (Just helpDoc)
+        <>  Options.value Apache
+        )
+
+    readLogFormat = Options.maybeReader \case
+      "quiet" -> Just Quiet
+      "default" -> Just Apache
+      "real-ip" -> Just ApacheWithForwarding
+      "verbose" -> Just Verbose
+      "debug" -> Just VerboseNoColor
+      _ -> Nothing
+
     helpDoc = Options.nest 2 $ Options.vsep
       [ "Use of of these output formats:"
       , "quiet   - do not log"
@@ -181,30 +218,43 @@ parseLogFormat =
       , "debug   - verbose logging with uncolored output"
       ]
 
-readLogFormat :: Options.ReadM LogFormat
-readLogFormat = Options.maybeReader \case
-  "quiet" -> Just Quiet
-  "default" -> Just Apache
-  "real-ip" -> Just ApacheWithForwarding
-  "verbose" -> Just Verbose
-  "debug" -> Just VerboseNoColor
-  _ -> Nothing
 
-parseOptions :: Parser Options
-parseOptions = do
-    socket <- parseTcp <|> parseUnix
+parseStores :: Parser (NonEmpty ByteString)
+parseStores = fmap toNE . Options.many $ Options.strOption
+  (   Options.long "store"
+  <>  Options.helpDoc (Just helpDoc)
+  <>  Options.metavar "STORE"
+  )
+  where
+    toNE = fromMaybe (NonEmpty.singleton "") . NonEmpty.nonEmpty
+    helpDoc = Options.vsep
+        [ "nix store uri. see: man nix3-help-stores"
+        , "Maybe be provided more than once. Respects the `priority` setting if given multiple stores."
+        ]
 
-    ssl <- parseSsl
+parseRetryTimeout :: Parser (Maybe Word)
+parseRetryTimeout = optional $ Options.option Options.auto
+    (   Options.long "retry-timeout"
+    <>  Options.helpDoc (Just helpDoc)
+    <>  Options.metavar "SECONDS"
+    )
+    where
+      helpDoc = Options.hsep
+        [ "Timeout before retying a remote after a connection fails."
+        , "Default to nix.settings.connect-timeout"
+        ]
 
-    priority <- parsePriority
-
-    timeout <- parseTimeout
-
-    store <- parseStore
-
-    logFormat <- parseLogFormat
-
-    return Options{..}
+parseCores :: Parser (Maybe Int)
+parseCores = optional $ Options.option Options.auto
+    (   Options.long "cores"
+    <>  Options.helpDoc (Just helpDoc)
+    <>  Options.metavar "N"
+    )
+    where
+      helpDoc = Options.hsep
+        [ "The number of cores to use"
+        , "Defaults to the largest number of --store args with the same priority."
+        ]
 
 parseReader :: Parsec Void String a -> ReadM a
 parseReader parser =
@@ -212,68 +262,3 @@ parseReader parser =
         case Megaparsec.parse parser "(input)" string of
             Left bundle -> Left (Megaparsec.errorBundlePretty bundle)
             Right a     -> Right a
-
--- This is only for backwards compatibility with nix-serve, which supports
--- the --listen option
-parseListen :: Parser Options
-parseListen = do
-    let parseTcpListen :: Parsec Void String Socket
-        parseTcpListen = do
-            host <- parseHost <|> pure "*"
-
-            _ <- ":"
-
-            port <- Lexer.decimal
-
-            -- See: [NOTE: enable-ssl]
-            _ <- optional ":ssl"
-
-            return TCP{..}
-
-    let parseUnixListen :: Parsec Void String Socket
-        parseUnixListen = do
-            let backlog = defaultBacklog
-
-            path <- Megaparsec.takeRest
-
-            return Unix{..}
-
-    let parseSocketListen = parseTcpListen <|> parseUnixListen
-
-    ssl <- parseSsl
-
-    socket <- Options.option (parseReader parseSocketListen)
-        (   Options.long "listen"
-        <>  Options.short 'l'
-        <>  Options.help "The TLS-enabled host and port to bind to"
-        <>  Options.metavar "[HOST]:PORT|UNIX_SOCKET"
-        <>  Options.hidden
-        )
-
-    priority <- parsePriority
-
-    timeout <- parseTimeout
-
-    store <- parseStore
-
-    logFormat <- parseLogFormat
-
-    return Options{..}
-
-parserInfo :: ParserInfo Options
-parserInfo =
-    Options.info
-        (Options.helper <*> (parseOptions <|> parseListen))
-        (Options.progDesc "Serve the current Nix store as a binary cache")
-
-parseHost :: Parsec Void String HostPreference
-parseHost = do
-    let ipv6 = Megaparsec.try do
-          proto <- Megaparsec.takeWhileP Nothing (/= '[') <* "["
-          addr <- Megaparsec.takeWhileP Nothing (/= ']') <* "]"
-          _ <- Megaparsec.lookAhead ":"
-          pure . fromString $ proto <> "[" <> addr <> "]"
-
-    let other = Megaparsec.takeWhileP Nothing (/= ':')
-
-    fmap fromString $ ipv6 <|> other


### PR DESCRIPTION
nix-serve-ng` can connect to other substituters with the --store option.

URL is a standard nix store url see: `nix help-stores` for details.

`--store=URL` can be specified more than once. Stores will be queried order of the `priority` query parameter (lowest to highest). Sets of stores with the same priority will be queried concurrently.

`--retry-timeout=SECONDS` specifies how long to wait after a store operation fails before reenabling the store. The default is the value of the nix setting `connect-timeout`.

`--cores=N` specifies the maximum number of cores. The default value is the size of the largest group of stores with the same priority.